### PR TITLE
Use dashboard layout for Batch list view

### DIFF
--- a/app/controllers/hyrax/batch_ingest/application_controller.rb
+++ b/app/controllers/hyrax/batch_ingest/application_controller.rb
@@ -1,6 +1,6 @@
 module Hyrax
   module BatchIngest
-    class ApplicationController < ActionController::Base
+    class ApplicationController < Hyrax::MyController
       protect_from_forgery with: :exception
     end
   end

--- a/app/views/hyrax/batch_ingest/batches/_batch.html.erb
+++ b/app/views/hyrax/batch_ingest/batches/_batch.html.erb
@@ -1,0 +1,11 @@
+<tr>
+  <td><%= batch.id %></td>
+  <td><%= batch.status %></td>
+  <td><%= batch.error.message %></td>
+  <td><%= batch.submitter_email %></td>
+  <td><%= batch.source_path %></td>
+  <td><%= batch.admin_set.name %></td>
+  <td><%= batch.collection.name %></td>
+  <td><%= batch.created_at %></td>
+  <td><%= batch.updated_at %></td>
+</tr>

--- a/app/views/hyrax/batch_ingest/batches/index.html.erb
+++ b/app/views/hyrax/batch_ingest/batches/index.html.erb
@@ -1,0 +1,25 @@
+<h1><span class="fa fa-copy"></span>Batches</h1>
+
+<% if @batches %>
+  <div class='table-responsive'>
+    <table class='table table-condensed'>
+      <thead>
+        <th scope='col'>ID</th>
+        <th scope='col'>Status</th>
+        <th scope='col'>Error Message</th>
+        <th scope='col'>Submitter email address</th>
+        <th scope='col'>Filename</th>
+        <th scope='col'>Admin Set</th>
+        <th scope='col'>Collection</th>
+        <th scope='col'>Created</th>
+        <th scope='col'>Updated</th>
+      </thead>
+      <tbody>
+        <%= render @batches %>
+      </tbody>
+    </table>
+  </div>
+<% else %>
+  <br />
+  <h4>Batches?!... Batches?!... We don't need no stinking Batches!</h4><br />
+<% end %>

--- a/hyrax-batch_ingest.gemspec
+++ b/hyrax-batch_ingest.gemspec
@@ -17,6 +17,10 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   s.add_dependency "rails", "~> 5.1.6"
+  s.add_dependency "hyrax", "~> 2.2.0"
+  # This needs to be pinned to 11.5.2 because Hyrax won't install otherwise,
+  # because of some bizzare error eraised in cases where AF is *not* 11.5.2.
+  s.add_dependency "active-fedora", "11.5.2"
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails", "~> 3.8"

--- a/hyrax-batch_ingest.gemspec
+++ b/hyrax-batch_ingest.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails", "~> 3.8"
+  s.add_development_dependency "factory_bot_rails", "~> 4.11"
 end

--- a/lib/hyrax/batch_ingest.rb
+++ b/lib/hyrax/batch_ingest.rb
@@ -4,5 +4,10 @@ require 'hyrax'
 module Hyrax
   module BatchIngest
     # Your code goes here...
+    class << self
+      def root
+        Pathname.new File.dirname(File.dirname(File.dirname(File.expand_path(__FILE__))))
+      end
+    end
   end
 end

--- a/lib/hyrax/batch_ingest.rb
+++ b/lib/hyrax/batch_ingest.rb
@@ -1,4 +1,5 @@
 require "hyrax/batch_ingest/engine"
+require 'hyrax'
 
 module Hyrax
   module BatchIngest

--- a/spec/factories/hyrax_factories.rb
+++ b/spec/factories/hyrax_factories.rb
@@ -1,0 +1,20 @@
+# Specify a list of Hyrax factories to require.
+hyrax_factories = [
+  # 'admin_sets',
+  # 'permission_templates',
+  # 'permission_template_accesses',
+  # 'collections',
+  # 'collections_factory',
+  # 'collection_types',
+  # 'collection_type_participants',
+  # 'collection_branding_infos',
+  # 'object_id',
+  'users'
+  # 'workflows',
+  # 'workflow_actions'
+]
+
+# Require the Hyrax factories specified in hyrax_factories
+hyrax_factories.each do |hyrax_factory|
+  require File.join(Hyrax::Engine.root, 'spec', 'factories', hyrax_factory)
+end

--- a/spec/features/batches/list_batches_spec.rb
+++ b/spec/features/batches/list_batches_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe 'List Batches', type: :feature do
+  context 'as a Batch Ingest Admin User' do
+    let(:admin) { create(:admin) }
+    before { login_as admin }
+
+    describe 'default view' do
+      before { visit '/batches' }
+      it 'has the header "Batches"' do
+        # TODO: more specialized matcher for page header?
+        expect(page).to have_header 'Batches'
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -25,7 +25,7 @@ EngineCart.load_application!
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+Dir[Hyrax::BatchIngest.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/support/custom_matchers.rb
+++ b/spec/support/custom_matchers.rb
@@ -1,0 +1,7 @@
+module CustomMatchers
+  def have_header(text)
+    have_css 'h1', text: text
+  end
+end
+
+RSpec.configure { |c| c.include CustomMatchers }

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,5 @@
+require 'factory_bot'
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+  FactoryBot.find_definitions
+end

--- a/spec/support/warden.rb
+++ b/spec/support/warden.rb
@@ -1,0 +1,8 @@
+RSpec.configure do |config|
+  config.include Warden::Test::Helpers, type: :feature
+  config.after(:each, type: :feature) do
+    Warden.test_reset!
+    Capybara.reset_sessions!
+    page.driver.reset!
+  end
+end

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -1,3 +1,6 @@
 # EngineCart will use this file to load gems into your test app.
 # Place gems in this file that you want available in your test app, but don't
 # want to require as a gem dependency.
+
+gem 'pry-byebug'
+gem 'launchy'

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -1,1 +1,3 @@
-gem 'hyrax'
+# EngineCart will use this file to load gems into your test app.
+# Place gems in this file that you want available in your test app, but don't
+# want to require as a gem dependency.


### PR DESCRIPTION
* Adds partials for the list view, with headers.
* Adds a simple feature spec for checking the header of the List Batches view.
* Makes Hyrax::BatchesController extend Hyrax::MyController. This lets us use
  the Hyrax Dashboard, and probably a bunch of other stuff too that we may or
  may not need.
* Adds .root method to return root dir of Hyrax::BatchIngest gem.
* Loads all spec support files by default.
* Adds Warden config for feature specs to a spec support file, so  we can use
  login_as.
* Adds FactoryBot config to a spec support file, so we can create an admin user
  to login with.
* Adds a module for adding custom matchers to a spec support file, and adds a
  simple custom matcher, 'has_header' to check for page headers.
* Loads selected factories from Hyrax gem, starting with 'users'.
* Adds pry-byebug to Gemfile.extra. Now you can call binding.pry in tests.
* Adds launchy to the Gemfile.extra. Now you can all save_and_open_page in
  tests.