### PR TITLE
Adds Config object for BatchIngest

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,3 +17,7 @@ Bundler/DuplicatedGem:
 RSpec/ExampleLength:
   Exclude:
     - 'spec/lib/hyrax/batch_ingest/routing/batch_item_routes_spec.rb'
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/lib/hyrax/batch_ingest/config_spec.rb'

--- a/lib/hyrax/batch_ingest/config.rb
+++ b/lib/hyrax/batch_ingest/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yaml'
 require 'hyrax/batch_ingest/error'
 
@@ -35,12 +37,12 @@ module Hyrax
 
         def raw_config
           File.read config_file_path
-        rescue Errno::ENOENT => e
+        rescue Errno::ENOENT
           raise Hyrax::BatchIngest::Error::MissingConfig
         end
 
         def parsed_yaml
-          @parsed_yaml ||= YAML.load(raw_config)
+          @parsed_yaml ||= YAML.safe_load(raw_config)
         end
 
         def default_config_file_path

--- a/lib/hyrax/batch_ingest/config.rb
+++ b/lib/hyrax/batch_ingest/config.rb
@@ -1,0 +1,51 @@
+require 'yaml'
+require 'hyrax/batch_ingest/error'
+
+module Hyrax
+  module BatchIngest
+    class Config
+      attr_reader :config_file_path, :ingest_type
+
+      def initialize(ingest_type:, config_file_path: nil)
+        @config_file_path = config_file_path || default_config_file_path
+        @ingest_type = ingest_type
+        config
+      end
+
+      def reader
+        # TODO: Raise custom error on invalid Reader
+        @config['reader']
+      end
+
+      def source_validator
+        # TODO: Raise custom error on invalid SourceValidator
+        @config['source_validator']
+      end
+
+      def mapper
+        # TODO: Raise custom error on invalid Mapper
+        @config['mapper']
+      end
+
+      private
+
+        def config
+          @config ||= parsed_yaml['ingest_types'][ingest_type]
+        end
+
+        def raw_config
+          File.read config_file_path
+        rescue Errno::ENOENT => e
+          raise Hyrax::BatchIngest::Error::MissingConfig
+        end
+
+        def parsed_yaml
+          @parsed_yaml ||= YAML.load(raw_config)
+        end
+
+        def default_config_file_path
+          Rails.root.join('config', 'batch_ingest.yml')
+        end
+    end
+  end
+end

--- a/lib/hyrax/batch_ingest/error.rb
+++ b/lib/hyrax/batch_ingest/error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Hyrax
   module BatchIngest
     module Error

--- a/lib/hyrax/batch_ingest/error.rb
+++ b/lib/hyrax/batch_ingest/error.rb
@@ -1,0 +1,8 @@
+module Hyrax
+  module BatchIngest
+    module Error
+      class MissingConfig < StandardError; end
+      class InvalidConfig < StandardError; end
+    end
+  end
+end

--- a/spec/fixtures/example_config/invalid_config.yml
+++ b/spec/fixtures/example_config/invalid_config.yml
@@ -1,0 +1,1 @@
+this is not a yaml file!!

--- a/spec/fixtures/example_config/invalid_config.yml
+++ b/spec/fixtures/example_config/invalid_config.yml
@@ -1,1 +1,0 @@
-this is not a yaml file!!

--- a/spec/fixtures/example_config/valid_config.yml
+++ b/spec/fixtures/example_config/valid_config.yml
@@ -1,0 +1,7 @@
+---
+ingest_types:
+  example_ingest_type:
+    label: "Example Ingest Type"
+    reader: "ExampleReader"
+    source_validator: "ExampleSourceValidator"
+    mapper: "ExampleMapper"

--- a/spec/lib/hyrax/batch_ingest/config_spec.rb
+++ b/spec/lib/hyrax/batch_ingest/config_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 require 'hyrax/batch_ingest/config'
 
@@ -8,7 +10,7 @@ RSpec.describe Hyrax::BatchIngest::Config do
     context 'with a valid config file' do
       let(:config_file_path) { File.join(fixture_path, 'example_config', 'valid_config.yml') }
       it 'loads without error' do
-        expect{ config }.to_not raise_error
+        expect { config }.not_to raise_error
       end
 
       describe 'reader' do
@@ -33,7 +35,7 @@ RSpec.describe Hyrax::BatchIngest::Config do
     context 'with an non-existent config file' do
       let(:config_file_path) { 'not_a_file' }
       it 'raises a InvalidConfig error' do
-        expect{ config }.to raise_error Hyrax::BatchIngest::Error::MissingConfig
+        expect { config }.to raise_error Hyrax::BatchIngest::Error::MissingConfig
       end
     end
   end

--- a/spec/lib/hyrax/batch_ingest/config_spec.rb
+++ b/spec/lib/hyrax/batch_ingest/config_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+require 'hyrax/batch_ingest/config'
+
+RSpec.describe Hyrax::BatchIngest::Config do
+  describe '.new' do
+    let(:config) { described_class.new(ingest_type: 'example_ingest_type', config_file_path: config_file_path) }
+
+    context 'with a valid config file' do
+      let(:config_file_path) { File.join(fixture_path, 'example_config', 'valid_config.yml') }
+      it 'loads without error' do
+        expect{ config }.to_not raise_error
+      end
+
+      describe 'reader' do
+        it 'returns the reader value for the ingest type' do
+          expect(config.reader).to eq 'ExampleReader'
+        end
+      end
+
+      describe 'mapper' do
+        it 'returns the mapper value for the ingest type' do
+          expect(config.mapper).to eq 'ExampleMapper'
+        end
+      end
+
+      describe 'source_validator' do
+        it 'returns the source_validator for the ingest type' do
+          expect(config.source_validator).to eq 'ExampleSourceValidator'
+        end
+      end
+    end
+
+    context 'with an non-existent config file' do
+      let(:config_file_path) { 'not_a_file' }
+      it 'raises a InvalidConfig error' do
+        expect{ config }.to raise_error Hyrax::BatchIngest::Error::MissingConfig
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -39,7 +39,7 @@ end
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.fixture_path = "#{Hyrax::BatchIngest.root}/spec/fixtures"
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
Hyrax::BatchIngest::Config reads config from a YAML file and provides accessors
to config values for a given ingest type.

The YAML file can be specified on instantiation and defaults to a conventional
location at {Rails.root}/config/batch_ingest.yml.

Current recognized config accessors include:
  * reader
  * mapper
  * source_validator
  * label

Also...
  * Adds fixtures for example configs.
  * Adds Error module to contain custom error classes.