### PR TITLE
Adds integration test for Batch Details page

### DIFF
--- a/app/controllers/hyrax/batch_ingest/batches_controller.rb
+++ b/app/controllers/hyrax/batch_ingest/batches_controller.rb
@@ -1,10 +1,16 @@
 # frozen_string_literal: true
+
 module Hyrax
   module BatchIngest
     class BatchesController < Hyrax::BatchIngest::ApplicationController
-      def index; end
+      skip_authorize_resource
+      def index
+        @batches = Batch.all
+      end
 
-      def show; end
+      def show
+        @batch = Batch.find(params[:id])
+      end
     end
   end
 end

--- a/app/views/hyrax/batch_ingest/batches/show.html.erb
+++ b/app/views/hyrax/batch_ingest/batches/show.html.erb
@@ -1,0 +1,27 @@
+<h1><span class="fa fa-copy"></span>Batch Details</h1>
+
+<div class='table-responsive'>
+  <table class='table table-condensed'>
+    <thead>
+      <tr>
+        <th scope='col'>Status</th>
+        <th scope='col'>ID Within Batch</th>
+        <th scope='col'>Source Location</th>
+        <th scope='col'>Repository ID</th>
+        <th scope='col'>Error</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @batch.batch_items.each_with_index do |item, index| %>
+        <tr class="batch-item <%= item.status %>" data-batch-item-id="<%= item.id %>">
+          <td><span data-toggle="collapse" data-target="#error_<%= index %>" class="clickable" style="cursor: pointer;"><%= item.status %></span></td>
+          <td><%= item.id_within_batch %></td>
+          <td><%= item.source_location %></td>
+          <td><%= item.object_id %></td>
+          <td><%= item.error %></td>
+        </tr>
+        <!-- TODO: copy Donut's expandable row containing error information  -->
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/spec/factories/batch.rb
+++ b/spec/factories/batch.rb
@@ -3,8 +3,17 @@
 FactoryBot.define do
   factory :batch, class: Hyrax::BatchIngest::Batch do
     admin_set_id { 'gid://internal/AdminSet/default' }
-    submitter_email { 'archivist1@example.com' }
     source_location { 'path/to/batch_manifest.csv' }
     status { :complete }
+    sequence(:submitter_email) { |n| "batch_submitter_#{n}@example.org" }
+    error {}
+
+    after(:build) do |batch, evaluator|
+      evaluator.batch_items.each { |batch_item| batch_item.batch = batch }
+    end
+
+    after(:create) do |batch, evaluator|
+      evaluator.batch_items.each { |batch_item| batch_item.batch = batch }
+    end
   end
 end

--- a/spec/factories/batch_item.rb
+++ b/spec/factories/batch_item.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :batch_item do
-    batch
-    id_within_batch
+  factory :batch_item, class: Hyrax::BatchIngest::BatchItem do
+    sequence(:id_within_batch) { |n| n }
     source_data { '{ title: ["Title"], creator: ["Jane Doe"], keyword: ["test"]}' }
     source_location { 'path/to/batch_manifest.csv' }
     status { :complete }
-    error
-    object_id
+    error { nil }
+    object_id { '12345678' }
   end
 end

--- a/spec/features/batches/show_batch_details_spec.rb
+++ b/spec/features/batches/show_batch_details_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe 'Show Batches Data', type: :feature do
+  context 'as a Batch Ingest Admin User' do
+    let(:admin) { create(:admin) }
+    before { login_as admin }
+
+    describe 'default view' do
+      let(:batch) { create(:batch, batch_items: build_list(:batch_item, 5)) }
+      before { visit "/batches/#{batch.id}" }
+
+      it 'show batch details and list of batch items' do
+        expect(page).to have_header "Batch Details"
+        # TODO: expect to see other details of the batch record.
+        expect(page).to only_have_batch_item_rows batch.batch_items
+      end
+    end
+  end
+end

--- a/spec/support/custom_matchers.rb
+++ b/spec/support/custom_matchers.rb
@@ -3,6 +3,42 @@ module CustomMatchers
   def have_header(text)
     have_css 'h1', text: text
   end
+
+  # Returns a matcher for whether the given batch_item is in the batch's list of
+  # items. The select used is a data attribute containing the BatchItem ID.
+  def have_batch_item_row(batch_item)
+    raise_argument_error_if_not_batch_items batch_item
+    have_css("tr[data-batch-item-id=\"#{batch_item.id}\"]")
+  end
+
+  # Returns a matcher for whether all the given batch_items given are in the search
+  # results.
+  def have_batch_item_rows(batch_items = [])
+    raise_argument_error_if_not_batch_items batch_items
+    batch_items = batch_items.to_a.dup
+    batch_items.reduce have_batch_item_row(batch_items.shift) do |memo, batch_item|
+      memo.and(have_batch_item_row(batch_item))
+    end
+  end
+
+  # Returns a matcher for whether the given batch_items are the ONLY recrods in the
+  # serach results.
+  def only_have_batch_item_rows(batch_items = [])
+    raise_argument_error_if_not_batch_items batch_items
+    # Has all of the batch_items in the search results...
+    have_batch_item_rows(batch_items).and(
+      # ... and only has batch_items.count search results.
+      have_css("tr[data-batch-item-id]", count: batch_items.count)
+    )
+  end
+
+  def raise_argument_error_if_not_batch_items(batch_items = [])
+    batch_items = batch_items.to_a if batch_items.respond_to?(:to_a)
+    batch_items = Array(batch_items)
+
+    all_are_batch_items = batch_items.all? { |item| item.is_a? Hyrax::BatchIngest::BatchItem }
+    raise ArgumentError, "#{caller[0]} expects instance(s) of BatchItem, but '#{batch_items.map(&:class).join(', ')}' was given" unless all_are_batch_items
+  end
 end
 
 RSpec.configure { |c| c.include CustomMatchers }


### PR DESCRIPTION
* Adds several custom matchers for expecting to see specific BatchItem instances
  on a Batch Details page.
* Assigns @batches and @batch variables with BatchesController actions.
* For now, calls 'skip_authorization' in BatchesController.
* Fixes Batch and BatchItem factories to allow you to specify a list of
  BatchItem instances (using FactoryBot.build_list) when creating a Batch.

Closes #28.