### PR TITLE
Adds 'Upload New Batch' interface

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,9 +20,11 @@ RSpec/ExampleLength:
 
 Metrics/BlockLength:
   Exclude:
-    - 'spec/lib/hyrax/batch_ingest/config_spec.rb'
-    - 'spec/services/batch_runner_spec.rb'
+    - 'spec/**/*_spec.rb'
 
 RSpec/DescribeClass:
   Exclude:
     - 'spec/services/batch_runner_spec.rb'
+
+Style/RaiseArgs:
+  Enabled: false

--- a/app/controllers/hyrax/batch_ingest/batches_controller.rb
+++ b/app/controllers/hyrax/batch_ingest/batches_controller.rb
@@ -4,13 +4,60 @@ module Hyrax
   module BatchIngest
     class BatchesController < Hyrax::BatchIngest::ApplicationController
       skip_authorize_resource
+
+      def new
+        # We need to have some batch ingest types before we proceed.
+        if Hyrax::BatchIngest.config.ingest_types.empty?
+          flash[:notice] = "No batch ingest types have been configured."
+          redirect_back fallback_location: batches_url
+        end
+        @presenter = Hyrax::BatchIngest::BatchPresenter.new(Batch.new)
+        @admin_sets = available_admin_sets
+        @ingest_types = available_ingest_types
+      end
+
+      def create
+        @batch = Batch.new(strong_params)
+        if @batch.save
+          flash[:notice] = 'Batch Started'
+          redirect_to @batch
+        else
+          @presenter = presenter_for :new, @batch
+          render :new
+        end
+      end
+
       def index
+        # TODO: Restrict batches to those to which current_user is authorized
+        @presenters = Batch.all.map do |batch|
+          Hyrax::BatchIngest::BatchPresenter.new(batch)
+        end
         @batches = Batch.all
       end
 
       def show
-        @batch = Batch.find(params[:id])
+        @presenter = Hyrax::BatchIngest::BatchPresenter.new(Batch.find(strong_params[:id]))
       end
+
+      private
+
+        def available_admin_sets
+          # TODO: Restrict available_admin_sets to only those current user has
+          # access to.
+          @available_admin_sets ||= AdminSet.all.map do |admin_set|
+            [admin_set.title.first, admin_set.id]
+          end
+        end
+
+        def available_ingest_types
+          Hyrax::BatchIngest.config.ingest_types.map do |ingest_type, config|
+            [config.label, ingest_type]
+          end
+        end
+
+        def strong_params
+          params.permit(:id, :submitter_email)
+        end
     end
   end
 end

--- a/app/models/hyrax/batch_ingest/batch.rb
+++ b/app/models/hyrax/batch_ingest/batch.rb
@@ -7,5 +7,13 @@ module Hyrax::BatchIngest
     def completed?
       batch_items.all? { |item| item.status == :success || item.status == :failed }
     end
+
+    def admin_set
+      @admin_set ||= AdminSet.find(admin_set_id) if admin_set_id
+    end
+
+    def collection
+      # TODO: return instance of Collection object
+    end
   end
 end

--- a/app/presenters/hyrax/batch_ingest/batch_presenter.rb
+++ b/app/presenters/hyrax/batch_ingest/batch_presenter.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module BatchIngest
+    class BatchPresenter
+      attr_reader :batch
+      def initialize(batch)
+        @batch = batch
+      end
+
+      delegate :id, :submitter_email, :source_location, :batch_items, :error,
+               :created_at, :updated_at, to: :batch
+
+      def collection_title
+        batch.collection&.title&.first
+      end
+
+      def status
+        status_labels[batch.status]
+      end
+
+      def admin_set_title
+        batch.admin_set&.title&.first
+      end
+
+      private
+
+        def status_labels
+          # TODO: use i18n
+          {
+            started: "Batch Started",
+            processing: "Batch Processing",
+            complete: "Batch Complete"
+          }
+        end
+    end
+  end
+end

--- a/app/services/hyrax/batch_ingest/batch_runner.rb
+++ b/app/services/hyrax/batch_ingest/batch_runner.rb
@@ -55,7 +55,7 @@ module Hyrax
       private
 
         def config
-          @config ||= Hyrax::BatchIngest::Config.new(ingest_type: batch.ingest_type)
+          @config ||= Hyrax::BatchIngest.config.ingest_types[batch.ingest_type]
         end
 
         def notify_failed(exception)

--- a/app/views/hyrax/batch_ingest/batches/_batch.html.erb
+++ b/app/views/hyrax/batch_ingest/batches/_batch.html.erb
@@ -1,11 +1,11 @@
 <tr>
-  <td><%= batch.id %></td>
-  <td><%= batch.status %></td>
-  <td><%= batch.error.message %></td>
-  <td><%= batch.submitter_email %></td>
-  <td><%= batch.source_path %></td>
-  <td><%= batch.admin_set.name %></td>
-  <td><%= batch.collection.name %></td>
-  <td><%= batch.created_at %></td>
-  <td><%= batch.updated_at %></td>
+  <td><%= presenter.id %></td>
+  <td><%= presenter.status %></td>
+  <td><%= presenter.error %></td>
+  <td><%= presenter.submitter_email %></td>
+  <td><%= presenter.source_location %></td>
+  <td><%= presenter.admin_set_title %></td>
+  <td><%= presenter.collection_title %></td>
+  <td><%= presenter.created_at %></td>
+  <td><%= presenter.updated_at %></td>
 </tr>

--- a/app/views/hyrax/batch_ingest/batches/index.html.erb
+++ b/app/views/hyrax/batch_ingest/batches/index.html.erb
@@ -1,6 +1,8 @@
 <h1><span class="fa fa-copy"></span>Batches</h1>
 
-<% if @batches %>
+<a href="/batches/new" title="Upload New Batch">Upload New Batch</a>
+
+<% if @presenters.count > 0 %>
   <div class='table-responsive'>
     <table class='table table-condensed'>
       <thead>
@@ -15,7 +17,9 @@
         <th scope='col'>Updated</th>
       </thead>
       <tbody>
-        <%= render @batches %>
+        <% @presenters.each do |presenter| %>
+          <%= render 'batch', presenter: presenter %>
+        <% end %>
       </tbody>
     </table>
   </div>

--- a/app/views/hyrax/batch_ingest/batches/new.html.erb
+++ b/app/views/hyrax/batch_ingest/batches/new.html.erb
@@ -1,0 +1,9 @@
+<h1><%= t('.header') %></h1>
+
+<%= simple_form_for @presenter.batch do |f| %>
+  <%= f.input :ingest_type, collection: @ingest_types, required: true %>
+  <%= f.input :batch_source, as: :file, required: true %>
+  <%= f.input :submitter_email, as: :email, required: true %>
+  <%= f.input :admin_set_id, collection: @admin_sets, required: true %>
+  <%= f.button :submit,  value: 'Save' %>
+<% end %>

--- a/app/views/hyrax/batch_ingest/batches/show.html.erb
+++ b/app/views/hyrax/batch_ingest/batches/show.html.erb
@@ -12,7 +12,7 @@
       </tr>
     </thead>
     <tbody>
-      <% @batch.batch_items.each_with_index do |item, index| %>
+      <% @presenter.batch_items.each_with_index do |item, index| %>
         <tr class="batch-item <%= item.status %>" data-batch-item-id="<%= item.id %>">
           <td><span data-toggle="collapse" data-target="#error_<%= index %>" class="clickable" style="cursor: pointer;"><%= item.status %></span></td>
           <td><%= item.id_within_batch %></td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,6 @@
+en:
+  hyrax:
+    batch_ingest:
+      batches:
+        new:
+          header: "Upload New Batch"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 Hyrax::BatchIngest::Engine.routes.draw do
-  resources :batches, only: [:index, :show] do
+  resources :batches, only: [:index, :show, :new, :create] do
     resources :items, only: [:show], controller: 'batch_items'
   end
 end

--- a/lib/hyrax/batch_ingest.rb
+++ b/lib/hyrax/batch_ingest.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require "hyrax/batch_ingest/engine"
+require 'hyrax/batch_ingest/config'
 require 'hyrax'
 
 module Hyrax
@@ -8,6 +9,14 @@ module Hyrax
     class << self
       def root
         Pathname.new File.dirname(File.dirname(File.dirname(File.expand_path(__FILE__))))
+      end
+
+      def config
+        @config ||= Hyrax::BatchIngest::Config.new
+      end
+
+      def configure
+        yield(config) if block_given?
       end
     end
   end

--- a/lib/hyrax/batch_ingest/config.rb
+++ b/lib/hyrax/batch_ingest/config.rb
@@ -2,51 +2,53 @@
 
 require 'yaml'
 require 'hyrax/batch_ingest/errors'
+require 'hyrax/batch_ingest/ingest_type_config'
 
 module Hyrax
   module BatchIngest
     class Config
-      attr_reader :config_file_path, :ingest_type
+      attr_reader :config_file_path, :ingest_types
 
-      def initialize(ingest_type:, config_file_path: nil)
+      def initialize(config_file_path = nil)
         @config_file_path = config_file_path || default_config_file_path
-        @ingest_type = ingest_type
-        config
+        @ingest_types = {}
+        # Only attempt to load if a config file path was passed in OR if the
+        # default config file exists. Otherwise, don't load anything.
+        load_config(config_file_path) if config_file_path || File.exist?(default_config_file_path)
       end
 
-      def reader
-        # TODO: Raise custom error on invalid Reader
-        @config['reader']
+      # Loads configuration from the specified config file.
+      def load_config(config_file_path)
+        @config_file_path = config_file_path || default_config_file_path
+        @ingest_types = {}
+        parsed_yaml['ingest_types'].each do |ingest_type, options|
+          add_ingest_type_config(ingest_type, options)
+        end
       end
 
-      def source_validator
-        # TODO: Raise custom error on invalid SourceValidator
-        @config['source_validator']
+      def add_ingest_type_config(ingest_type, opts = {})
+        @ingest_types[ingest_type.to_sym] = Hyrax::BatchIngest::IngestTypeConfig.new(ingest_type, opts)
       end
 
-      def mapper
-        # TODO: Raise custom error on invalid Mapper
-        @config['mapper']
+      def ingest_type(ingest_type)
+        raise Hyrax::BatchIngest::UnrecognizedIngestTypeError.new(ingest_type) unless ingest_types.key? ingest_type
+        ingest_types[ingest_type]
+      end
+
+      def default_config_file_path
+        Rails.root.join('config', 'batch_ingest.yml')
       end
 
       private
-
-        def config
-          @config ||= parsed_yaml['ingest_types'][ingest_type]
-        end
-
-        def raw_config
-          File.read config_file_path
-        rescue Errno::ENOENT
-          raise Hyrax::BatchIngest::MissingConfig
-        end
 
         def parsed_yaml
           @parsed_yaml ||= YAML.safe_load(raw_config)
         end
 
-        def default_config_file_path
-          Rails.root.join('config', 'batch_ingest.yml')
+        def raw_config
+          File.read config_file_path
+        rescue Errno::ENOENT
+          raise Hyrax::BatchIngest::ConfigFileNotFoundError.new(config_file_path)
         end
     end
   end

--- a/lib/hyrax/batch_ingest/errors.rb
+++ b/lib/hyrax/batch_ingest/errors.rb
@@ -3,8 +3,42 @@
 module Hyrax
   module BatchIngest
     class BatchIngestError < ::StandardError; end
-    class MissingConfig < BatchIngestError; end
-    class InvalidConfig < BatchIngestError; end
     class ReaderError < BatchIngestError; end
+
+    class ConfigFileNotFoundError < BatchIngestError
+      def initialize(path)
+        super("Batch ingest config file not found: '#{path}'")
+      end
+    end
+
+    class InvalidConfigOptionsError < BatchIngestError
+      def initialize(invalid_options)
+        super("Invalid batch ingest configuration option(s): '#{Array(invalid_options).join("', '")}'")
+      end
+    end
+
+    class MissingRequiredConfigOptionsError < BatchIngestError
+      def initialize(required_config_options)
+        super("Mising requied configuration option(s): '#{Array(required_config_options).join("', '")}'")
+      end
+    end
+
+    class ReaderClassNotFoundError < BatchIngestError
+      def initialize(const_name)
+        super("Batch ingest reader class '#{const_name}' was not found")
+      end
+    end
+
+    class MapperClassNotFoundError < BatchIngestError
+      def initialize(const_name)
+        super("Batch ingest mapper class '#{const_name}' was not found")
+      end
+    end
+
+    class UnrecognizedIngestTypeError < BatchIngestError
+      def initialize(unrecognized_ingest_type)
+        super("Unrecognized batch ingest type: '#{unrecognized_ingest_type}'")
+      end
+    end
   end
 end

--- a/lib/hyrax/batch_ingest/ingest_type_config.rb
+++ b/lib/hyrax/batch_ingest/ingest_type_config.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+require 'hyrax/batch_ingest/errors'
+require "active_support/core_ext/hash/indifferent_access"
+
+module Hyrax
+  module BatchIngest
+    class IngestTypeConfig
+      attr_reader :ingest_type, :options
+
+      def initialize(ingest_type, opts = {})
+        @ingest_type = ingest_type.to_sym
+        @options = validate_options(opts)
+      end
+
+      def reader
+        @reader ||= Object.const_get(options[:reader])
+      rescue NameError
+        raise Hyrax::BatchIngest::ReaderClassNotFoundError.new(options[:reader])
+      end
+
+      def mapper
+        @mapper ||= Object.const_get(options[:mapper])
+      rescue NameError
+        raise Hyrax::BatchIngest::MapperClassNotFoundError.new(options[:mapper])
+      end
+
+      def label
+        options[:label]
+      end
+
+      private
+
+        def validate_options(options = {})
+          # Convert to hash with indifferent access to make accessing options
+          # less error-prone throughout.
+          options = options.with_indifferent_access
+          option_keys = options.keys.map(&:to_sym)
+          invalid_options = option_keys - valid_options
+          raise Hyrax::BatchIngest::InvalidConfigOptionsError.new(invalid_options) unless invalid_options.empty?
+          missing_required_options = required_options - option_keys
+          raise Hyrax::BatchIngest::MissingRequiredConfigOptionsError.new(missing_required_options) unless missing_required_options.empty?
+          options
+        end
+
+        # Returns an array of symbols representing valid options.
+        def valid_options
+          [:reader, :mapper, :label]
+        end
+
+        # Returns an array of symbols representing required options.
+        def required_options
+          valid_options - [:label]
+        end
+    end
+  end
+end

--- a/spec/controllers/hyrax/batch_ingest/batches_controller_spec.rb
+++ b/spec/controllers/hyrax/batch_ingest/batches_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Hyrax::BatchIngest::BatchesController, type: :controller do
+  routes { Hyrax::BatchIngest::Engine.routes }
+  let(:admin_user) { create :admin }
+
+  context 'when there are no ingest types configured' do
+    before do
+      # Login as an admin user
+      sign_in admin_user
+      # Set the batch ingest config to not have any ingest types.
+      allow(Hyrax::BatchIngest.config).to receive(:ingest_types).and_return({})
+    end
+
+    let(:response) { get :new }
+
+    it 'redirects the user back to /batches with a flash message' do
+      expect(response).to redirect_to(batches_url)
+      expect(flash[:notice]).to eq "No batch ingest types have been configured."
+    end
+  end
+end

--- a/spec/fixtures/example_config.yml
+++ b/spec/fixtures/example_config.yml
@@ -1,0 +1,10 @@
+---
+ingest_types:
+  example_ingest_type:
+    label: "Example Ingest Type"
+    reader: "ExampleReader"
+    mapper: "ExampleMapper"
+  other_ingest_type:
+    label: "Other Ingest Type"
+    reader: "OtherReader"
+    mapper: "OtherMapper"

--- a/spec/lib/hyrax/batch_ingest/config_spec.rb
+++ b/spec/lib/hyrax/batch_ingest/config_spec.rb
@@ -1,42 +1,50 @@
 # frozen_string_literal: true
-
 require 'rails_helper'
 require 'hyrax/batch_ingest/config'
 
 RSpec.describe Hyrax::BatchIngest::Config do
-  describe '.new' do
-    let(:config) { described_class.new(ingest_type: 'example_ingest_type', config_file_path: config_file_path) }
+  let(:config_file_path) { File.join(fixture_path, 'example_config.yml') }
+  let(:config) { described_class.new(config_file_path) }
 
-    context 'with a valid config file' do
-      let(:config_file_path) { File.join(fixture_path, 'example_config', 'valid_config.yml') }
-      it 'loads without error' do
-        expect { config }.not_to raise_error
-      end
+  describe 'ingest_types' do
+    it 'returns an array of IngestTypeConfig instances' do
+      expect(config.ingest_types.values).to all be_a(Hyrax::BatchIngest::IngestTypeConfig)
+    end
+  end
 
-      describe 'reader' do
-        it 'returns the reader value for the ingest type' do
-          expect(config.reader).to eq 'ExampleReader'
-        end
-      end
-
-      describe 'mapper' do
-        it 'returns the mapper value for the ingest type' do
-          expect(config.mapper).to eq 'ExampleMapper'
-        end
-      end
-
-      describe 'source_validator' do
-        it 'returns the source_validator for the ingest type' do
-          expect(config.source_validator).to eq 'ExampleSourceValidator'
-        end
+  describe 'ingest_type' do
+    context 'when given a recognized ingest type' do
+      it 'returns the IngestConfigType instance' do
+        expect(config.ingest_type(:example_ingest_type)).to be_a Hyrax::BatchIngest::IngestTypeConfig
+        expect(config.ingest_type(:other_ingest_type)).to be_a Hyrax::BatchIngest::IngestTypeConfig
       end
     end
 
-    context 'with an non-existent config file' do
-      let(:config_file_path) { 'not_a_file' }
-      it 'raises a InvalidConfig error' do
-        expect { config }.to raise_error Hyrax::BatchIngest::MissingConfig
+    context 'when given an unrecognized ingest type' do
+      it 'raises an UnrecognizedIngestType error' do
+        expect { config.ingest_type(:not_an_ingest_type) }.to raise_error Hyrax::BatchIngest::UnrecognizedIngestTypeError
       end
+    end
+  end
+
+  describe '#add_ingest_type_config' do
+    before do
+      config.add_ingest_type_config(
+        'foo',
+        reader: 'FooReader',
+        mapper: 'FooMapper'
+      )
+    end
+
+    it 'allows adding ingest type config at runtime' do
+      expect(config.ingest_types[:foo]).to be_a Hyrax::BatchIngest::IngestTypeConfig
+    end
+  end
+
+  context 'with an non-existent config file' do
+    let(:config_file_path) { 'not_a_file' }
+    it 'raises a ConfigFileNotFound error' do
+      expect { config }.to raise_error Hyrax::BatchIngest::ConfigFileNotFoundError
     end
   end
 end

--- a/spec/lib/hyrax/batch_ingest/ingest_type_config_spec.rb
+++ b/spec/lib/hyrax/batch_ingest/ingest_type_config_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'hyrax/batch_ingest/ingest_type_config'
+
+RSpec.describe Hyrax::BatchIngest::IngestTypeConfig do
+  describe '.new' do
+    context 'with invalid options' do
+      let(:ingest_type_config) { described_class.new('example_ingest_type', blerg: "this is an invalid option") }
+      it 'raises an InvalidIngestTypeConfigOption error' do
+        expect { ingest_type_config }.to raise_error Hyrax::BatchIngest::InvalidConfigOptionsError
+      end
+    end
+
+    context 'when missing required options' do
+      let(:ingest_type_config) { described_class.new('example_ingest_type', reader: 'ExampleReader') }
+      it 'raises a MissingRequiredConfigOptionsError error' do
+        expect { ingest_type_config }.to raise_error Hyrax::BatchIngest::MissingRequiredConfigOptionsError
+      end
+    end
+  end
+
+  context 'when the specified classes exist' do
+    before do
+      # some test classes
+      class ExampleReader; end
+      class ExampleMapper; end
+    end
+
+    let(:ingest_type_config) do
+      described_class.new('example_ingest_type', reader: 'ExampleReader',
+                                                 mapper: 'ExampleMapper',
+                                                 label: 'Example Mapper')
+    end
+
+    describe '#reader' do
+      it 'returns the value of the :reader config option' do
+        expect(ingest_type_config.reader).to eq ExampleReader
+      end
+    end
+
+    describe 'mapper' do
+      it 'returns the mapper value for the ingest type' do
+        expect(ingest_type_config.mapper).to eq ExampleMapper
+      end
+    end
+
+    describe '#label' do
+      it 'returns the label for the ingest type' do
+        expect(ingest_type_config.label).to eq 'Example Mapper'
+      end
+    end
+
+    # clean up test classes
+    after do
+      Object.send(:remove_const, :ExampleReader)
+      Object.send(:remove_const, :ExampleMapper)
+    end
+  end
+
+  context 'when the specified classes do not exist' do
+    let(:ingest_type_config) do
+      described_class.new('example_ingest_type', reader: 'ClassDoesNotExist',
+                                                 mapper: 'ClassDoesNotExist')
+    end
+
+    describe '#reader' do
+      it 'raises a Hyrax::BatchIngest::ReaderClassNotFoundError' do
+        expect { ingest_type_config.reader }.to raise_error Hyrax::BatchIngest::ReaderClassNotFoundError
+      end
+    end
+
+    describe '#mapper' do
+      it 'raises a Hyrax::BatchIngest::ReaderClassNotFoundError' do
+        expect { ingest_type_config.mapper }.to raise_error Hyrax::BatchIngest::MapperClassNotFoundError
+      end
+    end
+  end
+end

--- a/spec/lib/hyrax/batch_ingest_spec.rb
+++ b/spec/lib/hyrax/batch_ingest_spec.rb
@@ -8,4 +8,18 @@ describe Hyrax::BatchIngest do
       expect(Hyrax::BatchIngest::VERSION).to match semver_pattern
     end
   end
+
+  describe '.config' do
+    it 'returns an instance of Hyrax::BatchIngest::Config' do
+      expect(described_class.config).to be_a Hyrax::BatchIngest::Config
+    end
+  end
+
+  describe '.configure' do
+    it 'takes a block and passes the Hyrax::BatchIngest::Config instance to it' do
+      described_class.configure do |config|
+        expect(config).to be_a Hyrax::BatchIngest::Config
+      end
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -39,7 +39,7 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 
 RSpec.configure do |config|
-  # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
+  # Define the fixture_path directory
   config.fixture_path = "#{Hyrax::BatchIngest.root}/spec/fixtures"
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.include Devise::Test::ControllerHelpers, type: :controller
+end

--- a/spec/test_app_templates/config/example_batch_ingest.yml
+++ b/spec/test_app_templates/config/example_batch_ingest.yml
@@ -1,0 +1,5 @@
+ingest_types:
+  wgbh_ingest:
+    label: 'WGBH Ingest'
+    reader: WGBHReader
+    mapper: WGBHMapper

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -21,4 +21,18 @@ class TestAppGenerator < Rails::Generators::Base
   def install_engine
     generate 'hyrax:batch_ingest:install'
   end
+
+  # TODO: BROKEN - NEEDS TO RUN AFTER FEDORA/SOLR HAVE STARTED.
+  def create_default_admin_set
+    rake 'hyrax:default_admin_set:create'
+  end
+
+  def add_example_batch_ingest_config
+    # TODO: the line below doesn't work. Currently need to copy by hand .
+    copy_file 'config/example_batch_ingest.yml', 'config/batch_ingest.yml'
+  end
+
+  def add_admin_user
+    # TODO
+  end
 end


### PR DESCRIPTION
**WAIT FOR PR #60 TO BE MERGED FIRST!** The `upload_batch_interface` branch (for this PR) was rebased onto the `batch_runner` branch (for PR #60), and then modified to correct some logical discrepancies.

**This PR includes:**
* Implement BatchesController actions #new and #create.
* Creates a form on new view for BatchesController#new.
* Enforce strong params on BatchesController
* Adds a BatchPresenter object.
* Modifies BatchesController and views to use BatchPresenter object.
* Refactors Config object.
* Adds new steps for test app generator:
  * create default admin set.
  * create default admin user (stubbed).
  * copy batch ingest config for development/testing.