### PR TITLE
Enable codeclimate and refactor rubocop config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,6 @@ jobs:
       NOKOGIRI_USE_SYSTEM_LIBRARIES: true
       ENGINE_CART_RAILS_OPTIONS: --skip-git --skip-bundle --skip-listen --skip-spring --skip-yarn --skip-keeps --skip-coffee --skip-puma --skip-test
       COVERALLS_PARALLEL: true
-      CC_TEST_REPORTER_ID: ${CC_TEST_REPORTER_ID}
 
     steps:
     - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
       NOKOGIRI_USE_SYSTEM_LIBRARIES: true
       ENGINE_CART_RAILS_OPTIONS: --skip-git --skip-bundle --skip-listen --skip-spring --skip-yarn --skip-keeps --skip-coffee --skip-puma --skip-test
       COVERALLS_PARALLEL: true
+      CC_TEST_REPORTER_ID: ${CC_TEST_REPORTER_ID}
 
     steps:
     - restore_cache:
@@ -93,10 +94,17 @@ jobs:
           curl -H 'Content-type: application/json' http://localhost:8985/api/collections/ -d '{create: {name: hydra-test, config: hyrax, numShards: 1}}'
 
     - run:
+        command: |
+          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+          chmod +x ./cc-test-reporter
+          ./cc-test-reporter before-build
+
+    - run:
         name: Run rspec
         command: |
           mkdir /tmp/test-results
-          bundle exec rake spec
+          COVERAGE=true bundle exec rake spec
+          ./cc-test-reporter after-build -t simplecov --exit-code $?
 
     - run:
         name: Clean dependencies

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,32 @@
+---
+prepare:
+  fetch:
+  - url: "https://raw.githubusercontent.com/samvera-labs/bixby/master/bixby_default.yml"
+    path: "bixby_default.yml"
+  - url: "https://raw.githubusercontent.com/samvera-labs/bixby/master/bixby_rails_enabled.yml"
+    path: "bixby_rails_enabled.yml"
+  - url: "https://raw.githubusercontent.com/samvera-labs/bixby/master/bixby_rspec_enabled.yml"
+    path: "bixby_rspec_enabled.yml"
+engines:
+  brakeman:
+    enabled: true
+  duplication:
+    enabled: false
+  rubocop:
+    enabled: true
+    channel: rubocop-0-50
+    config:
+      file: .rubocop.cc.yml
+ratings:
+  paths:
+  - Gemfile.lock
+  - "**.erb"
+  - "**.rb"
+  - "**.js"
+  - "**.es6"
+  - "**.coffee"
+  - "**.rake"
+  - "**.scss"
+exclude_paths:
+- config/
+- vendor/

--- a/.rubocop.cc.yml
+++ b/.rubocop.cc.yml
@@ -1,0 +1,7 @@
+inherit_from:
+  - bixby_default.yml
+  - .rubocop.exceptions.yml
+
+AllCops:
+  TargetRubyVersion: 2.3
+  DisplayCopNames: true

--- a/.rubocop.exceptions.yml
+++ b/.rubocop.exceptions.yml
@@ -1,13 +1,3 @@
-inherit_gem:
-  bixby: bixby_default.yml
-
-inherit_from:
-  - .rubocop.exceptions.yml
-
-AllCops:
-  TargetRubyVersion: 2.3
-  DisplayCopNames: true
-
 Naming/FileName:
   Exclude:
     - 'Gemfile'

--- a/hyrax-batch_ingest.gemspec
+++ b/hyrax-batch_ingest.gemspec
@@ -17,15 +17,17 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "rails", "~> 5.1.6"
-  s.add_dependency "hyrax", "~> 2.2"
+  s.add_dependency 'rails', '~> 5.1.6'
+  s.add_dependency 'hyrax', '~> 2.2'
 
   s.add_development_dependency 'bixby'
   s.add_development_dependency 'capybara'
+  s.add_development_dependency 'codeclimate-test-reporter'
   s.add_development_dependency 'coffee-rails'
-  s.add_development_dependency "factory_bot_rails", "~> 4.11"
+  s.add_development_dependency 'factory_bot_rails', '~> 4.11'
   s.add_development_dependency 'fcrepo_wrapper'
-  s.add_development_dependency "sqlite3"
-  s.add_development_dependency "rspec-rails", "~> 3.8"
+  s.add_development_dependency 'rspec-rails', '~> 3.8'
+  s.add_development_dependency 'simplecov'
   s.add_development_dependency 'solr_wrapper'
+  s.add_development_dependency 'sqlite3'
 end

--- a/hyrax-batch_ingest.gemspec
+++ b/hyrax-batch_ingest.gemspec
@@ -30,4 +30,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'solr_wrapper'
   s.add_development_dependency 'sqlite3'
+
+  # Pinned dependencies
+  s.add_development_dependency 'sass', '=3.6.0'
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,17 @@
 # frozen_string_literal: true
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
+
+if ENV['COVERAGE']
+  require 'simplecov'
+  require 'codeclimate-test-reporter'
+
+  SimpleCov.start('rails') do
+    add_filter '/spec'
+  end
+  SimpleCov.command_name 'spec'
+end
+
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../.internal_test_app/config/environment', __FILE__)
 # Prevent database truncation if the environment is production


### PR DESCRIPTION
Changes to the rubocop config should go into `.rubocop.exceptions.yml` since it will be inherited in both the default and codeclimate config files.

I opened a ticket in bixby to figure out how to better support this use case with `inherit_from` using a URI.  That would simplify the code climate config and maybe could help us unify the rubocop configs so we don't need a separate one for code climate.
https://github.com/samvera-labs/bixby/issues/27