### PR TITLE
Use BatchRunner in BatchesController

### DIFF
--- a/app/controllers/hyrax/batch_ingest/batches_controller.rb
+++ b/app/controllers/hyrax/batch_ingest/batches_controller.rb
@@ -80,7 +80,7 @@ module Hyrax
         def start_batch_runner(batch)
           Hyrax::BatchIngest::BatchRunner.new(batch: batch).run
         end
-      
+
         # Avoid SQL injection attack on ActiveRecord order method
         # Input must be in format "column asc" or "column desc"
         def sanitize_order(order_param)

--- a/app/controllers/hyrax/batch_ingest/batches_controller.rb
+++ b/app/controllers/hyrax/batch_ingest/batches_controller.rb
@@ -8,6 +8,7 @@ module Hyrax
       def new
         # We need to have some batch ingest types before we proceed.
         if Hyrax::BatchIngest.config.ingest_types.empty?
+          # TODO: Add a hint as to how/where to add ingest types to config.
           flash[:notice] = "No batch ingest types have been configured."
           redirect_back fallback_location: batches_url
         end
@@ -21,11 +22,11 @@ module Hyrax
         # TODO: Is the original_filename is what we really want to put
         # in source_location?
         @batch.source_location = params['batch']['batch_source'].original_filename
-        # TODO: status should only be set to 'accepted' after validation of all
-        # other fields succeeds.
-        @batch.status = 'accepted'
-        # TODO: Use BatchRunner to kick off the ingest process.
-        if @batch.save
+        @batch.status = 'received'
+
+        if @batch.valid?
+          # This will kick off jobs to process the batch.
+          start_batch_runner(@batch)
           flash[:notice] = 'Batch Started'
           redirect_to @batch
         else
@@ -64,6 +65,10 @@ module Hyrax
 
         def batch_params
           params.require(:batch).permit(:submitter_email, :ingest_type, :admin_set_id)
+        end
+
+        def start_batch_runner(batch)
+          Hyrax::BatchIngest::BatchRunner.new(batch: batch).run
         end
     end
   end

--- a/app/services/hyrax/batch_ingest/batch_runner.rb
+++ b/app/services/hyrax/batch_ingest/batch_runner.rb
@@ -9,8 +9,7 @@ module Hyrax
         @batch ||= Batch.new(ingest_type: ingest_type,
                              source_location: source_location,
                              admin_set_id: admin_set_id,
-                             submitter_email: submitter_email,
-                             status: 'received')
+                             submitter_email: submitter_email)
       end
 
       def run
@@ -20,9 +19,11 @@ module Hyrax
       end
 
       def initialize_batch
+        batch.status = 'received'
         batch.save! # batch received
       rescue ActiveRecord::ActiveRecordError => e
         notify_failed(e)
+        false
       end
 
       def read

--- a/db/migrate/20181022204812_create_hyrax_batch_ingest_batch_items.rb
+++ b/db/migrate/20181022204812_create_hyrax_batch_ingest_batch_items.rb
@@ -3,7 +3,6 @@
 class CreateHyraxBatchIngestBatchItems < ActiveRecord::Migration[5.1]
   def change
     create_table :hyrax_batch_ingest_batch_items do |t|
-
       t.references :batch, foreign_key: { to_table: :hyrax_batch_ingest_batches }, index: { name: :index_hyrax_batch_ingest_batch_items_on_batch_id }
       t.string :id_within_batch
       t.string :source_data

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -85,11 +85,4 @@ RSpec.configure do |config|
   # NOTE: for controller specs, put the following in the spec's describe block:
   #  routes { Hyrax::BatchIngest::Engine.routes }
   config.include Hyrax::BatchIngest::Engine.routes.url_helpers, type: :feature
-
-  config.before(:context) do
-    # Load a default example configuration for Hyrax::BatchIngest before each
-    # context. To test a different configuration file, simply call
-    # Hyrax::BatchIngest.config.load_config before individual tests.
-    Hyrax::BatchIngest.config.load_config(File.join(fixture_path, 'example_config.yml'))
-  end
 end

--- a/spec/support/batch_ingest_config.rb
+++ b/spec/support/batch_ingest_config.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Load a default example configuration for Hyrax::BatchIngest before each
+# context, providing the classes specified in the configuration.
+# To load a different batch ingest config file call
+# Hyrax::BatchIngest.config.load_config().
+RSpec.configure do |config|
+  config.before(:context) do
+    Hyrax::BatchIngest.config.load_config(File.join(fixture_path, 'example_config.yml'))
+    class ExampleReader < Hyrax::BatchIngest::BatchReader; end
+  end
+end


### PR DESCRIPTION
* Use BatchRunner in BatchesController#create action.
* Returns false from BatchRunner#initiate_batch if it fails to save the Batch.
* Adds spec for batches_controller#create action.
* Adds a dummy batch fixture (empty file) for creating a fake file upload.
* Fixes rubocop for db migration.

Closes #78.