### PR TITLE
Don't run rubocop in circleci since it runs in codeclimate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,10 +71,6 @@ jobs:
           bundle install
 
     - run:
-        name: Call Rubocop
-        command: bundle exec rubocop
-
-    - run:
         name: Generate test app, ensure top-level Gemfile.lock is valid
         command: |
           [ -e ./.internal_test_app ] || bundle exec rake engine_cart:generate


### PR DESCRIPTION
Fixes #83.  Replaces #89.

Saves ~2 sec from the circleci build.