### PR TITLE
Modifies BatchRunner

### DIFF
--- a/app/services/hyrax/batch_ingest/batch_runner.rb
+++ b/app/services/hyrax/batch_ingest/batch_runner.rb
@@ -14,26 +14,30 @@ module Hyrax
       end
 
       def run
-        initialize_batch
-        read
-        enqueue
+        if initialize_batch
+          # rubocop:disable Style/IfUnlessModifier
+          if read
+            enqueue
+          end
+        end
       end
 
       def initialize_batch
         batch.save! # batch received
       rescue ActiveRecord::ActiveRecordError => e
         notify_failed(e)
+        false
       end
 
       def read
         raise ArgumentError, "Batch not initialized yet" unless batch.persisted?
         reader = config.reader.new(batch.source_location)
-        batch.batch_items = reader.batch_items # batch item initialized (and now persisted)
-        ensure_submitter_email(reader)
-        batch.status = 'accepted'
+        fail_on_mismatch(batch, reader)
+        populate_batch_from_reader(batch, reader)
         batch.save! # batch accepted
       rescue ReaderError, ActiveRecord::ActiveRecordError => e
         notify_failed(e)
+        false
       end
 
       def enqueue
@@ -47,18 +51,26 @@ module Hyrax
         # TODO: Send email that batch has been enqueued
       rescue ActiveRecord::ActiveRecordError => e
         notify_failed(e)
+        false
       end
 
       private
 
-        def ensure_submitter_email(reader)
-          if reader.submitter_email.present?
-            if batch.submitter_email.present? && batch.submitter_email != reader.submitter_email
-              raise ReaderError, "Conflict: Different submitter emails found (#{batch.submitter_email} and #{reader.submitter_email})"
-            else
-              batch.submitter_email = reader.submitter_email
+        # Compare values from batch object with values read in from the reader.
+        # Raise errors on any mismatches that are supposed to match.
+        def fail_on_mismatch(batch, reader)
+          [:submitter_email, :admin_set_id].each do |field_name|
+            if batch.send(field_name) && reader.send(field_name) && (batch.send(field_name) != reader.send(field_name))
+              raise ReaderError, "Conflict: Different values for #{field_name.to_s.tr('_', ' ')} found (#{batch.send(field_name)} and #{reader.send(field_name)})"
             end
           end
+        end
+
+        def populate_batch_from_reader(batch, reader)
+          batch.batch_items = reader.batch_items # batch item initialized (and now persisted)
+          batch.submitter_email = reader.submitter_email if reader.submitter_email.present?
+          batch.admin_set_id = reader.admin_set_id if reader.admin_set_id.present?
+          batch.status = 'accepted'
         end
 
         def config

--- a/spec/services/batch_runner_spec.rb
+++ b/spec/services/batch_runner_spec.rb
@@ -98,6 +98,7 @@ RSpec.describe Hyrax::BatchIngest::BatchRunner do
         allow(reader_class).to receive(:new).with(batch.source_location).and_return(reader)
         allow(reader).to receive(:batch_items).and_return(batch_items)
         allow(reader).to receive(:submitter_email).and_return(submitter_email)
+        allow(reader).to receive(:admin_set_id)
         batch_runner.initialize_batch
       end
 
@@ -149,6 +150,8 @@ RSpec.describe Hyrax::BatchIngest::BatchRunner do
 
           before do
             allow(bad_reader_class).to receive(:new).with(batch.source_location).and_return(bad_reader)
+            allow(bad_reader).to receive(:submitter_email)
+            allow(bad_reader).to receive(:admin_set_id)
             allow(bad_reader).to receive(:batch_items).and_raise(Hyrax::BatchIngest::ReaderError, "Invalid batch")
           end
 


### PR DESCRIPTION
* Adds a single method #fail_on_mismatch for raising errors if any data is
  mismatched between data returned by the BatchReader instance and the Batch
  instance with which the BatchRunner was initialized. This replaces the one
  method #ensure_submitter_email, which was only checking submitter_email.
* Adds method #populate_batch_from_reader which is responsible for moving data
  from the BatchReader instance to the Batch instance.
* Adds FALSE return values for #initiate_batch, #read, and #enqueue steps, and
  modifies #run to only proceed to the next step if the previous step returns
  a truthy val.
* Modifes mocks in batch_runner_spec.rb as needed.

FYI - this PR contains some work that was in another PR that was superseded by another. I closed that original one, made a few more adjustments, and opened this one.

I'm not sure what to do about the negative coverage change. Lmk if what to do if you know.