### PR TITLE
Pass UploadedFile.path to batch

### DIFF
--- a/app/controllers/hyrax/batch_ingest/batches_controller.rb
+++ b/app/controllers/hyrax/batch_ingest/batches_controller.rb
@@ -17,8 +17,6 @@ module Hyrax
 
       def create
         @batch = Batch.new(batch_params)
-        # TODO: Is the original_filename is what we really want to put
-        # in source_location?
         @batch.source_location = params['batch']['batch_source'].path
         @batch.status = 'received'
 

--- a/app/controllers/hyrax/batch_ingest/batches_controller.rb
+++ b/app/controllers/hyrax/batch_ingest/batches_controller.rb
@@ -19,7 +19,7 @@ module Hyrax
         @batch = Batch.new(batch_params)
         # TODO: Is the original_filename is what we really want to put
         # in source_location?
-        @batch.source_location = params['batch']['batch_source'].original_filename
+        @batch.source_location = params['batch']['batch_source'].path
         @batch.status = 'received'
 
         if @batch.valid?


### PR DESCRIPTION
A full path to the batch is needed in order for our reader to open and read the contents of the batch so basename alone isn't enough.