### PR TITLE
Allows optional config for reader and ingeseter

### DIFF
--- a/lib/hyrax/batch_ingest/ingest_type_config.rb
+++ b/lib/hyrax/batch_ingest/ingest_type_config.rb
@@ -28,6 +28,14 @@ module Hyrax
         options[:label]
       end
 
+      def reader_options
+        options[:reader_options]
+      end
+
+      def ingester_options
+        options[:ingester_options]
+      end
+
       private
 
         def validate_options(options = {})
@@ -44,12 +52,12 @@ module Hyrax
 
         # Returns an array of symbols representing valid options.
         def valid_options
-          [:reader, :ingester, :label]
+          [:label, :reader, :reader_options, :ingester, :ingester_options]
         end
 
         # Returns an array of symbols representing required options.
         def required_options
-          valid_options - [:label]
+          valid_options - [:label, :reader_options, :ingester_options]
         end
     end
   end

--- a/spec/lib/hyrax/batch_ingest/config_spec.rb
+++ b/spec/lib/hyrax/batch_ingest/config_spec.rb
@@ -39,6 +39,25 @@ RSpec.describe Hyrax::BatchIngest::Config do
     it 'allows adding ingest type config at runtime' do
       expect(config.ingest_types[:foo]).to be_a Hyrax::BatchIngest::IngestTypeConfig
     end
+
+    context 'with additional config for custom Reader and Ingester classes' do
+      before do
+        config.add_ingest_type_config(
+          'bar',
+          reader: 'BarReader',
+          reader_options: {
+            opt_1: "pizza",
+            opt_2: "cookies"
+          },
+          ingester: 'BarIngester',
+          ingester_options: "single value param"
+        )
+      end
+
+      it 'allows specifying additional config for Reader and Ingester classes' do
+        expect(config.ingest_types[:bar]).to be_a Hyrax::BatchIngest::IngestTypeConfig
+      end
+    end
   end
 
   context 'with an non-existent config file' do

--- a/spec/lib/hyrax/batch_ingest/ingest_type_config_spec.rb
+++ b/spec/lib/hyrax/batch_ingest/ingest_type_config_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Hyrax::BatchIngest::IngestTypeConfig do
     let(:ingest_type_config) do
       described_class.new('example_ingest_type', reader: 'ExampleReader',
                                                  ingester: 'ExampleIngester',
-                                                 label: 'Example Ingester')
+                                                 label: 'Example Batch Ingest')
     end
 
     describe '#reader' do
@@ -39,7 +39,7 @@ RSpec.describe Hyrax::BatchIngest::IngestTypeConfig do
       end
     end
 
-    describe 'ingester' do
+    describe '#ingester' do
       it 'returns the ingester value for the ingest type' do
         expect(ingest_type_config.ingester).to eq ExampleIngester
       end
@@ -47,7 +47,31 @@ RSpec.describe Hyrax::BatchIngest::IngestTypeConfig do
 
     describe '#label' do
       it 'returns the label for the ingest type' do
-        expect(ingest_type_config.label).to eq 'Example Ingester'
+        expect(ingest_type_config.label).to eq 'Example Batch Ingest'
+      end
+    end
+
+    context 'when optional reader_options and ingester_options options are specified' do
+      let(:reader_options) { { 'opt1' => "reader option 1", 'opt2' => "reader option 1" } }
+      let(:ingester_options) { { 'opt1' => 'ingest option 1' } }
+      let(:ingest_type_config) do
+        described_class.new('example_ingest_type', reader: 'ExampleReader',
+                                                   reader_options: reader_options,
+                                                   ingester: 'ExampleIngester',
+                                                   ingester_options: ingester_options,
+                                                   label: 'Example Batch Ingest')
+      end
+
+      describe '#reader_options' do
+        it 'returns the reader options' do
+          expect(ingest_type_config.reader_options).to eq reader_options
+        end
+      end
+
+      describe '#ingester_options' do
+        it 'returns the optional config values' do
+          expect(ingest_type_config.ingester_options).to eq ingester_options
+        end
       end
     end
 


### PR DESCRIPTION
Adds 'reader_options' and 'ingester_options' as optional config options. These
values are then accessible on IngestTypeConfig object via `#reader_options` and
`#ingester_options` accessors.

TODO: The BatchRunner (and whichever other objects are responsible for
intantiating Reader and Ingester objects) need to pass these options along to
construtors for those classes.