### PR TITLE
Finish removal of source location from batch item table

### DIFF
--- a/app/views/hyrax/batch_ingest/batches/show.html.erb
+++ b/app/views/hyrax/batch_ingest/batches/show.html.erb
@@ -31,7 +31,6 @@
       <tr>
         <th scope='col'><%= sort_link_to('Status', 'status') %></th>
         <th scope='col'><%= sort_link_to('ID Within Batch', 'id_within_batch') %></th>
-        <th scope='col'><%= sort_link_to('Source Location', 'source_location') %></th>
         <th scope='col'><%= sort_link_to('Repository ID', 'object_id') %></th>
         <th scope='col'><%= sort_link_to('Error', 'error') %></th>
       </tr>


### PR DESCRIPTION
Source location was removed from `_batch_item.html.rb` but not from the table headers.  This PR fixes that mismatch.