### PR TITLE
Use left_joins to include batches that don't have any batch items

### DIFF
--- a/app/controllers/hyrax/batch_ingest/batches_controller.rb
+++ b/app/controllers/hyrax/batch_ingest/batches_controller.rb
@@ -37,7 +37,7 @@ module Hyrax
         @default_sort = 'created_at desc'
         # Restrict batches to those to which current_user is authorized
         # via cancancan's load_resource (which uses accessible_by)
-        @batches = @batches.joins(:batch_items)
+        @batches = @batches.left_joins(:batch_items)
                            .group(:batch_id, :id)
                            .order(sanitize_order(params[:order]))
                            .page(params[:page])


### PR DESCRIPTION
This fixes a problem where batches that don't have any batch items aren't displayed in the index view.