### PR TITLE
Removes shared spec

### DIFF
--- a/lib/hyrax/batch_ingest/spec/shared_specs/batch_item_ingester.rb
+++ b/lib/hyrax/batch_ingest/spec/shared_specs/batch_item_ingester.rb
@@ -17,18 +17,4 @@ RSpec.shared_examples "a Hyrax::BatchIngest::BatchItemIngester" do
       expect(ingester.batch_item).to eq batch_item
     end
   end
-
-  describe '#ingest' do
-    subject { ingester.ingest }
-
-    it 'creates a new object' do
-      expect { subject }.to change { ActiveFedora::Base.count }.by_at_least(1)
-    end
-
-    it 'returns a persisted object' do
-      expect(subject).to be_an ActiveFedora::Base
-      expect(subject).to be_persisted
-      expect(subject.id).to be_present
-    end
-  end
 end


### PR DESCRIPTION
Removes spec that checks for change in ActiveRecord::Base cardinality to simplify host application
tests, allowing extended item ingester objects to be tested without loading a full stack.