### PR TITLE
Set batch item status in callbacks

### DIFF
--- a/app/services/hyrax/batch_ingest/batch_runner.rb
+++ b/app/services/hyrax/batch_ingest/batch_runner.rb
@@ -45,7 +45,6 @@ module Hyrax
         # notify_failed("No batch items found.") if batch.batch_items.blank?
         batch.batch_items.each do |item|
           BatchItemProcessingJob.perform_later(item)
-          item.update(status: 'enqueued') # batch item enqueued
         end
         batch.update(status: 'enqueued') # batch enqueued
         BatchBeginMailer.with(batch: batch).batch_started_successfully.deliver_later

--- a/spec/jobs/batch_item_processing_job_spec.rb
+++ b/spec/jobs/batch_item_processing_job_spec.rb
@@ -16,21 +16,21 @@ describe Hyrax::BatchIngest::BatchItemProcessingJob do
     allow(ingester).to receive(:ingest).and_return(work)
   end
 
-  describe '#perform' do
+  describe '#perform (via #perform_now)' do
     let!(:batch) { FactoryBot.create(:enqueued_batch, batch_items: [batch_item]) }
 
     it 'runs the ingester' do
-      job.perform(batch_item)
+      job.perform_now
       expect(ingester).to have_received(:ingest)
     end
 
     it 'sets the BatchItem status to completed' do
-      job.perform(batch_item)
+      job.perform_now
       expect(batch_item.reload.status).to eq 'completed'
     end
 
     it 'updates the BatchItem with the created object id' do
-      job.perform(batch_item)
+      job.perform_now
       expect(batch_item.reload.repo_object_id).to eq work.id
     end
 


### PR DESCRIPTION
Before, BatchItem instances had their status set to 'enqueued' after they were
passed to the the BatchItemProcessingJob.perform_later. This caused issues with
batch item status when queue adapter is set to :inline (i.e. for testing),
because the job would finish, setting the batch item status to 'completed', but
then get flipped back to 'enqueued'.

By setting the batch item status to 'enqueued' in a after_enqueue callback, we
won't clobber the 'completed' status of jobs that may be run with :inline
adapter.