### PR TITLE
Fixes batch status when queue adapter is :inline

### DIFF
--- a/app/services/hyrax/batch_ingest/batch_runner.rb
+++ b/app/services/hyrax/batch_ingest/batch_runner.rb
@@ -42,11 +42,10 @@ module Hyrax
 
       def enqueue
         raise ArgumentError, "Batch not read yet" unless batch.status == 'accepted'
-        # notify_failed("No batch items found.") if batch.batch_items.blank?
+        batch.update(status: 'enqueued')
         batch.batch_items.each do |item|
           BatchItemProcessingJob.perform_later(item)
         end
-        batch.update(status: 'enqueued') # batch enqueued
         BatchBeginMailer.with(batch: batch).batch_started_successfully.deliver_later
       rescue ActiveRecord::ActiveRecordError => e
         notify_failed(e)


### PR DESCRIPTION
Another issue where the Batch status was getting set to "completed" within
BatchItemProcessingJob, but then getting switched back to "enqueued" afterward
in BatchRunner#enqueue. This happens when ActiveJob queue adapter is set to
:inline.