### PR TITLE
Pass along Reader and Ingester options

### DIFF
--- a/app/jobs/hyrax/batch_ingest/batch_item_processing_job.rb
+++ b/app/jobs/hyrax/batch_ingest/batch_item_processing_job.rb
@@ -35,13 +35,15 @@ module Hyrax
       end
 
       def perform(batch_item)
-        @work = config(batch_item).ingester.new(batch_item).ingest
+        ingester_class = config(batch_item).ingester
+        ingester_options = config(batch_item).ingester_options
+        @work = ingester_class.new(batch_item, ingester_options).ingest
       end
 
       private
 
         def config(batch_item)
-          @config ||= Hyrax::BatchIngest.config.ingest_types[batch_item.batch.ingest_type.to_sym]
+          Hyrax::BatchIngest.config.ingest_types[batch_item.batch.ingest_type.to_sym]
         end
     end
   end

--- a/app/services/hyrax/batch_ingest/batch_item_ingester.rb
+++ b/app/services/hyrax/batch_ingest/batch_item_ingester.rb
@@ -2,10 +2,11 @@
 module Hyrax
   module BatchIngest
     class BatchItemIngester
-      attr_reader :batch_item
+      attr_reader :batch_item, :options
 
-      def initialize(batch_item)
+      def initialize(batch_item, opts = {})
         @batch_item = batch_item
+        @options = opts || {}
       end
 
       def ingest

--- a/app/services/hyrax/batch_ingest/batch_reader.rb
+++ b/app/services/hyrax/batch_ingest/batch_reader.rb
@@ -3,14 +3,15 @@
 module Hyrax
   module BatchIngest
     class BatchReader
-      attr_reader :source_location
+      attr_reader :source_location, :options
 
-      def initialize(source_location)
+      def initialize(source_location, opts = {})
         @source_location = source_location
         @read = false
         @submitter_email = nil
         @batch_items = nil
         @admin_set_id = nil
+        @options = opts || {}
       end
 
       def submitter_email

--- a/app/services/hyrax/batch_ingest/batch_runner.rb
+++ b/app/services/hyrax/batch_ingest/batch_runner.rb
@@ -31,7 +31,7 @@ module Hyrax
 
       def read
         raise ArgumentError, "Batch not initialized yet" unless batch.persisted?
-        reader = config.reader.new(batch.source_location)
+        reader = config.reader.new(batch.source_location, config.reader_options)
         fail_on_mismatch(batch, reader)
         populate_batch_from_reader(batch, reader)
         batch.save! # batch accepted

--- a/lib/hyrax/batch_ingest/spec/shared_specs/batch_item_ingester.rb
+++ b/lib/hyrax/batch_ingest/spec/shared_specs/batch_item_ingester.rb
@@ -11,6 +11,7 @@ RSpec.shared_examples "a Hyrax::BatchIngest::BatchItemIngester" do
 
   it { is_expected.to respond_to :ingest }
   it { is_expected.to respond_to :batch_item }
+  it { is_expected.to respond_to :options }
 
   describe '#initialize' do
     it 'stores the batch_item' do

--- a/lib/hyrax/batch_ingest/spec/shared_specs/batch_reader.rb
+++ b/lib/hyrax/batch_ingest/spec/shared_specs/batch_reader.rb
@@ -17,6 +17,7 @@ RSpec.shared_examples "a Hyrax::BatchIngest::BatchReader" do
   it { is_expected.to respond_to :read }
   it { is_expected.to respond_to :been_read? }
   it { is_expected.to respond_to :source_location }
+  it { is_expected.to respond_to :options }
 
   describe '#initialize' do
     it 'stores the source_location' do

--- a/spec/jobs/batch_item_processing_job_spec.rb
+++ b/spec/jobs/batch_item_processing_job_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 describe Hyrax::BatchIngest::BatchItemProcessingJob do
   let(:batch) { FactoryBot.create(:enqueued_batch, batch_items: [batch_item]) }
   let(:batch_item) { FactoryBot.build(:batch_item, status: 'enqueued', repo_object_id: nil) }
-  let(:config) { instance_double(Hyrax::BatchIngest::IngestTypeConfig, ingester: ingester_class) }
+  let(:config) { instance_double(Hyrax::BatchIngest::IngestTypeConfig, ingester: ingester_class, ingester_options: {}) }
   let(:ingester_class) { double("IngesterClass") }
   let(:ingester) { double("BatchItemIngester") }
   let(:work) { double("work", id: 'new_object') }
@@ -12,7 +12,7 @@ describe Hyrax::BatchIngest::BatchItemProcessingJob do
 
   before do
     allow(job).to receive(:config).and_return(config)
-    allow(ingester_class).to receive(:new).with(batch_item).and_return(ingester)
+    allow(ingester_class).to receive(:new).with(batch_item, {}).and_return(ingester)
     allow(ingester).to receive(:ingest).and_return(work)
   end
 

--- a/spec/services/batch_runner_spec.rb
+++ b/spec/services/batch_runner_spec.rb
@@ -88,14 +88,14 @@ RSpec.describe Hyrax::BatchIngest::BatchRunner do
 
     context 'with batch initialized' do
       let(:batch) { FactoryBot.create(:initialized_batch) }
-      let(:config) { instance_double(Hyrax::BatchIngest::IngestTypeConfig, reader: reader_class) }
+      let(:config) { instance_double(Hyrax::BatchIngest::IngestTypeConfig, reader: reader_class, reader_options: {}) }
       let(:reader_class) { double("ReaderClass") }
       let(:reader) { double("BatchReader") }
       let(:batch_items) { [FactoryBot.build(:batch_item), FactoryBot.build(:batch_item)] }
 
       before do
         allow(batch_runner).to receive(:config).and_return(config)
-        allow(reader_class).to receive(:new).with(batch.source_location).and_return(reader)
+        allow(reader_class).to receive(:new).with(batch.source_location, {}).and_return(reader)
         allow(reader).to receive(:batch_items).and_return(batch_items)
         allow(reader).to receive(:submitter_email).and_return(submitter_email)
         allow(reader).to receive(:admin_set_id)
@@ -150,12 +150,12 @@ RSpec.describe Hyrax::BatchIngest::BatchRunner do
 
       context 'errors' do
         context 'with ReaderError' do
-          let(:config) { instance_double(Hyrax::BatchIngest::IngestTypeConfig, reader: bad_reader_class) }
+          let(:config) { instance_double(Hyrax::BatchIngest::IngestTypeConfig, reader: bad_reader_class, reader_options: {}) }
           let(:bad_reader_class) { double("ReaderClass") }
           let(:bad_reader) { double("BatchReader") }
 
           before do
-            allow(bad_reader_class).to receive(:new).with(batch.source_location).and_return(bad_reader)
+            allow(bad_reader_class).to receive(:new).with(batch.source_location, {}).and_return(bad_reader)
             allow(bad_reader).to receive(:submitter_email)
             allow(bad_reader).to receive(:admin_set_id)
             allow(bad_reader).to receive(:batch_items).and_raise(Hyrax::BatchIngest::ReaderError, "Invalid batch")


### PR DESCRIPTION
The ingester config allows implementers to specify arbitrary options in the config file
e.g. batch_ingest.yml. These options are available via instance methods #reader_options
and #ingester_options on instances of IngestConfigType objects. However, in the BatchRunner
and in the BatchItemProcessingJob objects, where Reader and Ingeter objects are
instantiated, those options were not being utilized. This PR passes the values from
IngestTypeConfig#reader_options and IngestTypeConfig#ingester_options to the constructors
of the reader and ingester classes respectively, which then are made available via
an #options attribute reader on both classes.