### PR TITLE
Refresh bundle of cached test app

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,12 @@ jobs:
         key: v3-internal-test-app-{{ checksum "hyrax-batch_ingest.gemspec" }}-{{ checksum "spec/test_app_templates/lib/generators/test_app_generator.rb" }}-{{ checksum "lib/generators/hyrax/batch_ingest/install_generator.rb" }}
 
     - run:
+        name: Install test app dependencies
+        command: |
+          cd .internal_test_app
+          bundle install
+          
+    - run:
         name: Load config into SolrCloud
         command: |
           cd .internal_test_app/solr/config


### PR DESCRIPTION
This additional `bundle install` handles the case when the cached internal test app has a Gemfile.lock that pins to a version of a gem disallowed by the plugin.