### PR TITLE
Avoid NoMethodError in rescue_from block

### DIFF
--- a/app/jobs/hyrax/batch_ingest/batch_item_processing_job.rb
+++ b/app/jobs/hyrax/batch_ingest/batch_item_processing_job.rb
@@ -30,7 +30,11 @@ module Hyrax
       rescue_from(StandardError) do |exception|
         batch_item = arguments.first
         # TODO: destroy any objects that were created
-        batch_item.update(status: 'failed', error: exception.message)
+        raise exception unless batch_item
+
+        error_msg = exception.message
+        error_msg += "<br><br>#{exception.backtrace.join('<br>')}" if Rails.env == "development"
+        batch_item.update(status: 'failed', error: error_msg)
         batch_item.batch.update(status: 'completed') if batch_item.batch.completed?
       end
 


### PR DESCRIPTION
The rescue_from block in BatchItemProcessingJob was assuming that BatchItem
object was successfully looked up, but some database errors were causing
it to be nil, which would raise a subsequent NoMethodError 'update' when
trying to call #update on nil class.

This PR adds a guard against that. Also appends a full backtrace to the error
message saved to the BatchItem when in development environment.