### PR TITLE
Uses named args for BatchItemProcessingJob#perform

### DIFF
--- a/app/jobs/hyrax/batch_ingest/batch_item_processing_job.rb
+++ b/app/jobs/hyrax/batch_ingest/batch_item_processing_job.rb
@@ -3,18 +3,18 @@ module Hyrax
   module BatchIngest
     class BatchItemProcessingJob < ApplicationJob
       before_enqueue do
-        batch_item = arguments.first
+        batch_item = named_arguments[:batch_item]
         batch_item.update(status: 'enqueued')
       end
 
       before_perform do
-        batch_item = arguments.first
+        batch_item = named_arguments[:batch_item]
         batch_item.batch.update(status: 'running') if batch_item.batch.status == 'enqueued'
         batch_item.update(status: 'running')
       end
 
       after_perform do
-        batch_item = arguments.first
+        batch_item = named_arguments[:batch_item]
         batch_item.update(status: 'completed', repo_object_id: @work.id)
         if batch_item.batch.completed?
           batch = batch_item.batch
@@ -28,7 +28,7 @@ module Hyrax
       end
 
       rescue_from(StandardError) do |exception|
-        batch_item = arguments.first
+        batch_item = named_arguments[:batch_item]
         # TODO: destroy any objects that were created
         raise exception unless batch_item
 
@@ -38,13 +38,25 @@ module Hyrax
         batch_item.batch.update(status: 'completed') if batch_item.batch.completed?
       end
 
-      def perform(batch_item)
+      def perform(batch_item:)
         ingester_class = config(batch_item).ingester
         ingester_options = config(batch_item).ingester_options
         @work = ingester_class.new(batch_item, ingester_options).ingest
       end
 
       private
+
+        # named_arguments
+        # Helper method for retrieving a hash of named arguments from
+        # #arguments. This comes in handy when you have named arguments in your
+        # #perform method, and need to access them by name in your before/after
+        # hooks (e.g. before_perform) whose blocks are only passed a single
+        # argument representing the job, but not the original arguments to
+        # the #perform method.
+        # @return Hash the hash of named arguments passed to #perform.
+        def named_arguments
+          arguments.select { |arg| arg.is_a? Hash }.first || {}
+        end
 
         def config(batch_item)
           Hyrax::BatchIngest.config.ingest_types[batch_item.batch.ingest_type.to_sym]

--- a/app/services/hyrax/batch_ingest/batch_runner.rb
+++ b/app/services/hyrax/batch_ingest/batch_runner.rb
@@ -45,8 +45,8 @@ module Hyrax
       def enqueue
         raise ArgumentError, "Batch not read yet" unless batch.status == 'accepted'
         batch.update(status: 'enqueued')
-        batch.batch_items.each do |item|
-          BatchItemProcessingJob.perform_later(item)
+        batch.batch_items.each do |batch_item|
+          BatchItemProcessingJob.perform_later(batch_item: batch_item)
         end
         BatchBeginMailer.with(batch: batch).batch_started_successfully.deliver_later
       rescue ActiveRecord::ActiveRecordError => e

--- a/spec/jobs/batch_item_processing_job_spec.rb
+++ b/spec/jobs/batch_item_processing_job_spec.rb
@@ -8,7 +8,7 @@ describe Hyrax::BatchIngest::BatchItemProcessingJob do
   let(:ingester_class) { double("IngesterClass") }
   let(:ingester) { double("BatchItemIngester") }
   let(:work) { double("work", id: 'new_object') }
-  let(:job) { described_class.new(batch_item) }
+  let(:job) { described_class.new(batch_item: batch_item) }
 
   before do
     allow(job).to receive(:config).and_return(config)

--- a/spec/services/batch_runner_spec.rb
+++ b/spec/services/batch_runner_spec.rb
@@ -196,8 +196,8 @@ RSpec.describe Hyrax::BatchIngest::BatchRunner do
 
       it 'enqueues the batch items from the reader' do
         batch_runner.enqueue
-        expect(Hyrax::BatchIngest::BatchItemProcessingJob).to have_been_enqueued.with(batch_items[0])
-        expect(Hyrax::BatchIngest::BatchItemProcessingJob).to have_been_enqueued.with(batch_items[1])
+        expect(Hyrax::BatchIngest::BatchItemProcessingJob).to have_been_enqueued.with(batch_item: batch_items[0])
+        expect(Hyrax::BatchIngest::BatchItemProcessingJob).to have_been_enqueued.with(batch_item: batch_items[1])
       end
 
       it 'sets the batch status to enqueued' do


### PR DESCRIPTION
We had a use case where we wanted to add additional BatchItems to a Batch during
ingest, but the jobs we used required additional params for the #perform method.
By using named params to BatchItemProcessingJob#perform, we can extend
BatchItemProcessingJob and override the #perform method with any number of
arguments we want, without having to worry about our overridden #perform method
messing up the callbacks used for managing the BatchItem instance.