### PR TITLE
Adds an batch ingest summary

### DIFF
--- a/.rubocop.exceptions.yml
+++ b/.rubocop.exceptions.yml
@@ -18,6 +18,10 @@ Metrics/BlockLength:
     - 'spec/**/*_spec.rb'
     - 'spec/factories/*.rb'
 
+Metrics/MethodLength:
+  Exclude:
+    - 'app/presenters/hyrax/batch_ingest/batch_summary_presenter.rb'
+
 RSpec/DescribeClass:
   Exclude:
     - 'spec/services/batch_runner_spec.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -47,3 +47,7 @@ else
   end
 end
 # END ENGINE_CART BLOCK
+
+group :development do
+  gem 'rb-readline'
+end

--- a/app/assets/stylesheets/hyrax/batch_ingest/batch_ingest.scss
+++ b/app/assets/stylesheets/hyrax/batch_ingest/batch_ingest.scss
@@ -1,0 +1,15 @@
+.batch-ingest-summary-section {
+  border-radius: 10px;
+  background: white;
+  padding: 10px;
+  margin: 10px 0;
+
+  h3 {
+    margin: 10px 0;
+  }
+}
+
+.footnote {
+  font-style: italic;
+  font-size: 1em
+}

--- a/app/controllers/hyrax/batch_ingest/batches_controller.rb
+++ b/app/controllers/hyrax/batch_ingest/batches_controller.rb
@@ -56,6 +56,10 @@ module Hyrax
         @presenter = Hyrax::BatchIngest::BatchPresenter.new(@batch)
       end
 
+      def summary
+        @presenter = Hyrax::BatchIngest::BatchSummaryPresenter.new(@batch)
+      end
+
       private
 
         def available_admin_sets

--- a/app/jobs/hyrax/batch_ingest/batch_item_processing_job.rb
+++ b/app/jobs/hyrax/batch_ingest/batch_item_processing_job.rb
@@ -33,7 +33,7 @@ module Hyrax
         raise exception unless batch_item
 
         error_msg = exception.message
-        error_msg += "<br><br>#{exception.backtrace.join('<br>')}" if Rails.env == "development"
+        error_msg += "\n\n#{exception.backtrace.join("\n")}" if Rails.env == "development"
         batch_item.update(status: 'failed', error: error_msg)
         batch_item.batch.update(status: 'completed') if batch_item.batch.completed?
       end

--- a/app/models/hyrax/batch_ingest/ability.rb
+++ b/app/models/hyrax/batch_ingest/ability.rb
@@ -10,7 +10,7 @@ module Hyrax
       def batch_abilities
         if admin?
           # exclude edit/update since we don't have such actions, keep destroy since we allow cancelling of a batch job
-          can [:new, :create, :index, :show, :read, :destroy], Hyrax::BatchIngest::Batch
+          can [:new, :create, :index, :show, :read, :destroy, :summary], Hyrax::BatchIngest::Batch
         else
           deposit_admin_sets = Hyrax::Collections::PermissionsService.source_ids_for_deposit(ability: self, source_type: 'admin_set')
           if deposit_admin_sets.present?

--- a/app/models/hyrax/batch_ingest/batch.rb
+++ b/app/models/hyrax/batch_ingest/batch.rb
@@ -31,5 +31,16 @@ module Hyrax::BatchIngest
       return nil if submitter_email.nil?
       @submitter ||= User.find_by! email: submitter_email
     end
+
+    def count_by_status
+      batch_items.group(:status).count
+    end
+
+    def count_by_object
+      batch_items
+        .where.not(repo_object_class_name: nil)
+        .group(:repo_object_class_name)
+        .count
+    end
   end
 end

--- a/app/presenters/hyrax/batch_ingest/batch_presenter.rb
+++ b/app/presenters/hyrax/batch_ingest/batch_presenter.rb
@@ -8,7 +8,7 @@ module Hyrax
       attr_reader :batch
 
       delegate :id, :submitter_email, :source_location, :batch_items, :error,
-               to: :batch
+               :count_by_status, :count_by_object, to: :batch
 
       def initialize(batch)
         @batch = batch
@@ -35,10 +35,6 @@ module Hyrax
         batch.updated_at.strftime(DATETIME_FORMAT)
       end
 
-      def batch_item_count
-        batch.batch_items.count
-      end
-
       def status_label
         self.class.status_labels[batch.status] || 'unknown'
       end
@@ -51,10 +47,18 @@ module Hyrax
         batch.admin_set&.title&.first
       end
 
+      def error_html
+        error.gsub("\n", "<br>")
+      end
+
       def batch_item_presenters
-        batch_items.map do |batch_item|
+        @batch_item_presenters ||= batch_items.map do |batch_item|
           Hyrax::BatchIngest::BatchItemPresenter.new(batch_item)
         end
+      end
+
+      def batch_item_count
+        @batch_item_count ||= batch.batch_items.count
       end
 
       class << self

--- a/app/presenters/hyrax/batch_ingest/batch_summary_presenter.rb
+++ b/app/presenters/hyrax/batch_ingest/batch_summary_presenter.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module BatchIngest
+    class BatchSummaryPresenter < BatchPresenter
+      def finished_summary
+        @finished_summary ||= begin
+          total = count_by_status.values_at('completed', 'failed').map(&:to_i).sum
+          {
+            total: total,
+            rows: [
+              {
+                count: count_by_status['completed'],
+                percent: percentage(count_by_status['completed'].to_i, total, 1),
+                status: 'Success'
+              },
+              {
+                count: count_by_status['failed'],
+                percent: percentage(count_by_status['failed'].to_i, total, 1),
+                status: 'Failed'
+              }
+            ]
+          }
+        end
+      end
+
+      def remaining_summary
+        @remaining_summary ||= begin
+          statuses_for_remaining = ['initialized', 'enqueued', 'running']
+          total = count_by_status.values_at(*statuses_for_remaining).map(&:to_i).sum
+          {
+            total: total,
+            rows: count_by_status.slice(*statuses_for_remaining).map do |status, count|
+              {
+                count: count,
+                percent: percentage(count.to_i, total, 1),
+                status: batch_item_status_label_for(status)
+              }
+            end
+          }
+        end
+      end
+
+      def object_summary
+        @object_summary ||= {
+          total: batch_items_ingested.count,
+          # Use BatchItem's count_by_object hash, and convert class names to
+          # their human readable counterparts if possible.
+          rows: count_by_object.map do |class_name, count|
+            {
+              count: count,
+              percent: percentage(count.to_i, batch_items_ingested.count, 1),
+              object_type: friendly_object_name(class_name)
+            }
+          end
+        }
+      end
+
+      def error_summary
+        @error_summary ||= {
+          total: batch_items_with_errors.count,
+          rows: error_summary_rows
+        }
+      end
+
+      private
+
+        def error_summary_rows
+          @error_summary_rows ||= begin
+            rows = {}
+            batch_items_with_errors.each do |batch_item|
+              error = batch_item.error.split("\n").first
+              if rows.key?(error)
+                rows[error][:count] += 1
+                rows[error][:ids_within_batch] << batch_item.id_within_batch
+              else
+                rows[error] = {
+                  count: 1,
+                  ids_within_batch: [batch_item.id_within_batch],
+                  error: error
+                }
+              end
+            end
+            # calculate percentages
+            rows.each_value { |row| row[:percent] = (100.0 * row[:count] / batch_items_with_errors.count).round(1) }
+            # return an array rows
+            rows.values
+          end
+        end
+
+        def batch_items_with_errors
+          @batch_items_with_errors ||= batch_items.select(&:error)
+        end
+
+        def batch_items_ingested
+          @batch_items_ingested ||= batch_items.select(&:repo_object_id)
+        end
+
+        def batch_item_status_label_for(status)
+          BatchItemPresenter.status_labels[status]
+        end
+
+        def percentage(numerator, denominator, decimal_places = 0)
+          (100.0 * numerator / denominator).round(decimal_places.to_i)
+        end
+
+        def friendly_object_name(class_name)
+          Object.const_get(class_name).model_name.human
+        rescue
+          class_name
+        end
+    end
+  end
+end

--- a/app/views/hyrax/batch_ingest/batches/show.html.erb
+++ b/app/views/hyrax/batch_ingest/batches/show.html.erb
@@ -21,7 +21,7 @@
   <dd><%= @presenter.source_location %></dd>
   <% if @presenter.error.present? %>
     <dt>Error:</dt>
-    <dd><%= @presenter.error %></dd>
+    <dd><%= @presenter.error_html %></dd>
   <% end %>
 </dl>
 
@@ -31,7 +31,7 @@
       <tr>
         <th scope='col'><%= sort_link_to('Status', 'status') %></th>
         <th scope='col'><%= sort_link_to('ID Within Batch', 'id_within_batch') %></th>
-        <th scope='col'><%= sort_link_to('Object Type', 'object_type') %></th>
+        <th scope='col'><%= sort_link_to('Object Type', 'repo_object_class_name') %></th>
         <th scope='col'><%= sort_link_to('Repository ID', 'repo_object_id') %></th>
       </tr>
     </thead>

--- a/app/views/hyrax/batch_ingest/batches/summary.html.erb
+++ b/app/views/hyrax/batch_ingest/batches/summary.html.erb
@@ -1,0 +1,19 @@
+<%= stylesheet_link_tag 'hyrax/batch_ingest/batch_ingest' %>
+
+<h1><span class="fa fa-copy"></span>Batch Ingest Summary</h1>
+
+<dl>
+  <dt>Ingest Type:</dt>
+  <dd><%= @presenter.ingest_type %></dd>
+  <dt>Submitter:</dt>
+  <dd><%= @presenter.submitter_email %></dd>
+  <dt>Admin Set:</dt>
+  <dd><%= @presenter.admin_set_title %></dd>
+  <dt>Status:</dt>
+  <dd><%= @presenter.status_label %></dd>
+</dl>
+
+<%= render partial: 'hyrax/batch_ingest/batches/summary/finished_summary', locals: @presenter.finished_summary %>
+<%= render partial: 'hyrax/batch_ingest/batches/summary/remaining_summary', locals: @presenter.remaining_summary %>
+<%= render partial: 'hyrax/batch_ingest/batches/summary/object_summary', locals: @presenter.object_summary %>
+<%= render partial: 'hyrax/batch_ingest/batches/summary/error_summary', locals: @presenter.error_summary  %>

--- a/app/views/hyrax/batch_ingest/batches/summary/_error_summary.html.erb
+++ b/app/views/hyrax/batch_ingest/batches/summary/_error_summary.html.erb
@@ -1,0 +1,32 @@
+<section class="batch-ingest-summary-section">
+  <h3><%= total %> Errors</h3>
+  <% unless rows.empty? %>
+    <div class="table-responsive">
+      <table class="table">
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>%</th>
+            <th>Error</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% rows.each_with_index do |row, i| %>
+            <tr>
+              <td><%= row[:count] %></td>
+              <td><%= row[:percent] %></td>
+              <td>
+                <%= row[:error] %>
+                <br>
+                <a style="cursor: pointer;" data-toggle="collapse" data-target="#ids_within_batch_<%= i %>">IDs Within Batch</a>
+                <div id="ids_within_batch_<%= i %>" class="collapse">
+                  <%= row[:ids_within_batch].join('<br>').html_safe %>
+                </div>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
+</section>

--- a/app/views/hyrax/batch_ingest/batches/summary/_finished_summary.html.erb
+++ b/app/views/hyrax/batch_ingest/batches/summary/_finished_summary.html.erb
@@ -1,0 +1,25 @@
+<section class="batch-ingest-summary-section">
+  <h3><%= total %> Batch Items Finished</h3>
+  <% unless rows.empty? %>
+    <div class="table-responsive">
+      <table class="table">
+        <thead>
+          <tr>
+            <th style="width: 5%;">#</th>
+            <th style="width: 5%;">%</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% rows.each do |row| %>
+            <tr>
+              <td><%= row[:count] %></td>
+              <td><%= row[:percent] %></td>
+              <td><%= row[:status] %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
+</section>

--- a/app/views/hyrax/batch_ingest/batches/summary/_object_summary.html.erb
+++ b/app/views/hyrax/batch_ingest/batches/summary/_object_summary.html.erb
@@ -1,0 +1,28 @@
+<section class="batch-ingest-summary-section">
+  <h3><%= total %> Objects Ingested <sup>*</sup></h3>
+  <% unless rows.empty? %>
+    <div class="table-responsive">
+      <table class="table">
+        <thead>
+          <tr>
+            <th style="width: 5%;">#</th>
+            <th style="width: 5%;">%</th>
+            <th>Object Type</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% rows.each do |row| %>
+            <td><%= row[:count] %></td>
+            <td><%= row[:percent] %></td>
+            <td><%= row[:object_type] %></td>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
+
+  <div class="footnote">
+    * This shows the number of each type of object ingested. However, there may
+      have been more objects created during the ingest process.
+  </div>
+</section>

--- a/app/views/hyrax/batch_ingest/batches/summary/_remaining_summary.html.erb
+++ b/app/views/hyrax/batch_ingest/batches/summary/_remaining_summary.html.erb
@@ -1,0 +1,25 @@
+<section class="batch-ingest-summary-section">
+  <h3><%= total %> Batch Items Remaining</h3>
+  <% unless rows.empty? %>
+    <div class="table-responsive">
+      <table class="table">
+        <thead>
+          <tr>
+            <th style="width: 5%;">#</th>
+            <th style="width: 5%;">%</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% rows.each do |row| %>
+            <tr>
+              <td><%= row[:count] %></td>
+              <td><%= row[:percent] %></td>
+              <td><%= row[:status] %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 Hyrax::BatchIngest::Engine.routes.draw do
-  resources :batches, only: [:index, :show, :new, :create]
+  resources :batches, only: [:index, :show, :new, :create] do
+    get 'summary', on: :member
+  end
 end

--- a/lib/hyrax/batch_ingest/engine.rb
+++ b/lib/hyrax/batch_ingest/engine.rb
@@ -3,6 +3,11 @@ module Hyrax
   module BatchIngest
     class Engine < ::Rails::Engine
       isolate_namespace Hyrax::BatchIngest
+
+      # Add engine's assets to Rails app's precompile list.
+      initializer "hyrax-batch_ingest.assets.precompile" do |app|
+        app.config.assets.precompile += %w[hyrax/batch_ingest/batch_ingest.scss]
+      end
     end
   end
 end

--- a/spec/factories/batch_item.rb
+++ b/spec/factories/batch_item.rb
@@ -8,12 +8,30 @@ FactoryBot.define do
     status { Hyrax::BatchIngest::BatchItem::STATUSES.sample }
     error { nil }
 
-    after(:build) do |batch_item, _evaluator|
-      # If the batch item is completed, add an object id and a class name if
-      # there isn't already one specified.
-      if batch_item.status == 'completed'
-        batch_item.repo_object_id ||= SecureRandom.uuid
-        batch_item.repo_object_class_name ||= 'GenericWork'
+    transient do
+      ensure_valid { true }
+    end
+
+    after(:build) do |batch_item, evaluator|
+      if evaluator.ensure_valid
+        # If the batch item is completed, add an object id and a class name if
+        # there isn't already one specified.
+        if batch_item.status == 'completed'
+          batch_item.repo_object_id ||= SecureRandom.uuid
+          batch_item.repo_object_class_name ||= 'GenericWork'
+        else
+          batch_item.repo_object_id = nil
+          batch_item.repo_object_class_name = nil
+          if batch_item.status == 'failed'
+            batch_item.error ||= [
+              'What the fluff?',
+              'All your base are blong to us',
+              'What we have here is failure to communicate',
+              'PC load letter',
+              'Thaks Mario, but our princess is in another castle!'
+            ].sample
+          end
+        end
       end
     end
   end

--- a/spec/features/batches/batch_summary_spec.rb
+++ b/spec/features/batches/batch_summary_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe 'Batch Summary', type: :feature do
+  context 'as a Batch Ingest Admin User' do
+    # build a big random list of batch items
+    let(:batch_items) { Array.new(rand(100..1000)) { build(:batch_item) } }
+
+    # calculate some totals expected for the summary
+    let(:num_finished) do
+      batch_items.select { |batch_item| batch_item.status.in? ['completed', 'failed'] }.count
+    end
+    let(:num_remaining) { batch_items.count - num_finished }
+    let(:num_errors) { batch_items.select(&:error).count }
+    let(:num_objects_ingested) { batch_items.select(&:repo_object_id).count }
+
+    # create a batch with the batch items
+    let(:batch) { create(:batch, batch_items: batch_items) }
+
+    # Go to the summary page before each example
+    before do
+      login_as create(:admin)
+      visit summary_batch_path(id: batch.id)
+    end
+
+    it 'shows the number of batch items finished' do
+      expect(page).to have_content "#{num_finished} Batch Items Finished"
+    end
+
+    it 'shows the number of batch items remaining' do
+      expect(page).to have_content "#{num_remaining} Batch Items Remaining"
+    end
+
+    it 'shows the number of objects ingested (according to BatchItem#repo_object_id)' do
+      expect(page).to have_content "#{num_objects_ingested} Objects Ingested"
+    end
+
+    it 'shows the number of errors' do
+      expect(page).to have_content "#{num_errors} Errors"
+    end
+  end
+end

--- a/spec/support/custom_matchers.rb
+++ b/spec/support/custom_matchers.rb
@@ -11,7 +11,7 @@ module CustomMatchers
     have_css("tr[data-batch-item-id=\"#{batch_item.id}\"]")
   end
 
-  # Returns a matcher for whether all the given batch_items given are in the search
+  # Returns a matcher for whether all the given batch_items are in the search
   # results.
   def have_batch_item_rows(batch_items = [])
     raise_argument_error_if_not_batch_items batch_items
@@ -21,8 +21,8 @@ module CustomMatchers
     end
   end
 
-  # Returns a matcher for whether the given batch_items are the ONLY recrods in the
-  # serach results.
+  # Returns a matcher for whether the given batch_items are the ONLY records in
+  # the search results.
   def only_have_batch_item_rows(batch_items = [])
     raise_argument_error_if_not_batch_items batch_items
     # Has all of the batch_items in the search results...


### PR DESCRIPTION
Shows:
  - total number and percentages of successes and failures
  - total number and percentage of remaining jobs by status
  - total number and percentage of objects ingested by object type
  - total number and percentage of unique errors, with a list of the
    'ID within batch' for each error, so you can get a list of where to look for
	the given errors.

Also,
* don't put <br> tags in BatchItem#error field when in development mode; use
  newline instead.
* fixes sort column for 'Object Type' in batches#show view.