### PR TITLE
Adds 'expunged' status

### DIFF
--- a/app/models/hyrax/batch_ingest/batch_item.rb
+++ b/app/models/hyrax/batch_ingest/batch_item.rb
@@ -2,7 +2,7 @@
 
 module Hyrax::BatchIngest
   class BatchItem < ApplicationRecord
-    STATUSES = ['initialized', 'enqueued', 'running', 'completed', 'failed'].freeze
+    STATUSES = ['initialized', 'enqueued', 'running', 'completed', 'failed', 'expunged'].freeze
 
     belongs_to :batch
     validates :status, inclusion: { in: STATUSES }

--- a/app/presenters/hyrax/batch_ingest/batch_item_presenter.rb
+++ b/app/presenters/hyrax/batch_ingest/batch_item_presenter.rb
@@ -44,7 +44,8 @@ module Hyrax
             enqueued:    I18n.t('hyrax.batch_ingest.batch_items.status.enqueued'),
             running:     I18n.t('hyrax.batch_ingest.batch_items.status.running'),
             completed:   I18n.t('hyrax.batch_ingest.batch_items.status.completed'),
-            failed:      I18n.t('hyrax.batch_ingest.batch_items.status.failed')
+            failed:      I18n.t('hyrax.batch_ingest.batch_items.status.failed'),
+            expunged:    I18n.t('hyrax.batch_ingest.batch_items.status.expunged')
           }.with_indifferent_access
         end
 
@@ -54,7 +55,8 @@ module Hyrax
             enqueued:     'fa fa-info',
             running:      'fa fa-refresh fa-sync',
             completed:    'fa fa-check-circle',
-            failed:       'fa fa-exclamation-triangle'
+            failed:       'fa fa-exclamation-triangle',
+            expunged:     'fa fa-exclamation-triangle'
           }.with_indifferent_access
         end
       end

--- a/app/presenters/hyrax/batch_ingest/batch_summary_presenter.rb
+++ b/app/presenters/hyrax/batch_ingest/batch_summary_presenter.rb
@@ -5,7 +5,7 @@ module Hyrax
     class BatchSummaryPresenter < BatchPresenter
       def finished_summary
         @finished_summary ||= begin
-          total = count_by_status.values_at('completed', 'failed').map(&:to_i).sum
+          total = count_by_status.values_at('completed', 'failed', 'expunged').map(&:to_i).sum
           {
             total: total,
             rows: [
@@ -18,6 +18,11 @@ module Hyrax
                 count: count_by_status['failed'],
                 percent: percentage(count_by_status['failed'].to_i, total, 1),
                 status: 'Failed'
+              },
+              {
+                count: count_by_status['expunged'],
+                percent: percentage(count_by_status['expunged'].to_i, total, 1),
+                status: 'Expunged'
               }
             ]
           }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,3 +18,4 @@ en:
           running: 'running'
           completed: 'completed'
           failed: 'failed'
+          expunged: 'expunged'

--- a/spec/features/batches/batch_summary_spec.rb
+++ b/spec/features/batches/batch_summary_spec.rb
@@ -8,7 +8,7 @@ describe 'Batch Summary', type: :feature do
 
     # calculate some totals expected for the summary
     let(:num_finished) do
-      batch_items.select { |batch_item| batch_item.status.in? ['completed', 'failed'] }.count
+      batch_items.select { |batch_item| batch_item.status.in? ['completed', 'failed', 'expunged'] }.count
     end
     let(:num_remaining) { batch_items.count - num_finished }
     let(:num_errors) { batch_items.select(&:error).count }


### PR DESCRIPTION
This status may be used to denote a BatchItem whose repo_object_id no longer represents an existing object in the repository.