### PR TITLE
Do not use 'expunged' status

### DIFF
--- a/app/models/hyrax/batch_ingest/batch_item.rb
+++ b/app/models/hyrax/batch_ingest/batch_item.rb
@@ -2,12 +2,19 @@
 
 module Hyrax::BatchIngest
   class BatchItem < ApplicationRecord
-    STATUSES = ['initialized', 'enqueued', 'running', 'completed', 'failed', 'expunged'].freeze
+    STATUSES = ['initialized', 'enqueued', 'running', 'completed', 'failed'].freeze
 
     belongs_to :batch
     validates :status, inclusion: { in: STATUSES }
     paginates_per 20
 
     delegate :submitter_email, :submitter, to: :batch
+
+    def repo_object_exists?
+      return false unless repo_object_id
+      !::SolrDocument.find(repo_object_id).nil?
+    rescue Blacklight::Exceptions::RecordNotFound
+      false
+    end
   end
 end

--- a/app/presenters/hyrax/batch_ingest/batch_summary_presenter.rb
+++ b/app/presenters/hyrax/batch_ingest/batch_summary_presenter.rb
@@ -5,7 +5,7 @@ module Hyrax
     class BatchSummaryPresenter < BatchPresenter
       def finished_summary
         @finished_summary ||= begin
-          total = count_by_status.values_at('completed', 'failed', 'expunged').map(&:to_i).sum
+          total = count_by_status.values_at('completed', 'failed').map(&:to_i).sum
           {
             total: total,
             rows: [
@@ -18,11 +18,6 @@ module Hyrax
                 count: count_by_status['failed'],
                 percent: percentage(count_by_status['failed'].to_i, total, 1),
                 status: 'Failed'
-              },
-              {
-                count: count_by_status['expunged'],
-                percent: percentage(count_by_status['expunged'].to_i, total, 1),
-                status: 'Expunged'
               }
             ]
           }

--- a/app/views/hyrax/batch_ingest/batches/_batch_item.html.erb
+++ b/app/views/hyrax/batch_ingest/batches/_batch_item.html.erb
@@ -3,8 +3,14 @@
   <td><%= presenter.id_within_batch %></td>
   <td><%= presenter.repo_object_display_name %></td>
   <td>
-    <% if presenter.repo_object_path %>
-      <%= link_to presenter.repo_object_id, presenter.repo_object_path %>
+    <% if presenter.repo_object_exists? %>
+      <% if presenter.repo_object_path %>
+        <%= link_to presenter.repo_object_id, presenter.repo_object_path %>
+      <% else %>
+        <%= presenter.repo_object_id %>
+      <% end %>
+    <% elsif presenter.status == 'completed' %>
+      <em>Gone</em>
     <% end %>
   </td>
 </tr>

--- a/app/views/hyrax/batch_ingest/batches/summary/_object_summary.html.erb
+++ b/app/views/hyrax/batch_ingest/batches/summary/_object_summary.html.erb
@@ -12,9 +12,11 @@
         </thead>
         <tbody>
           <% rows.each do |row| %>
-            <td><%= row[:count] %></td>
-            <td><%= row[:percent] %></td>
-            <td><%= row[:object_type] %></td>
+            <tr>
+              <td><%= row[:count] %></td>
+              <td><%= row[:percent] %></td>
+              <td><%= row[:object_type] %></td>
+            </tr>
           <% end %>
         </tbody>
       </table>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,4 +18,3 @@ en:
           running: 'running'
           completed: 'completed'
           failed: 'failed'
-          expunged: 'expunged'

--- a/spec/factories/batch_item.rb
+++ b/spec/factories/batch_item.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     source_data { '{ title: ["Title"], creator: ["Jane Doe"], keyword: ["test"]}' }
     source_location { 'path/to/batch_manifest.csv' }
     status { Hyrax::BatchIngest::BatchItem::STATUSES.sample }
+    repo_object_id { SecureRandom.uuid }
     error { nil }
 
     transient do
@@ -17,7 +18,6 @@ FactoryBot.define do
         # If the batch item is completed, add an object id and a class name if
         # there isn't already one specified.
         if batch_item.status == 'completed'
-          batch_item.repo_object_id ||= SecureRandom.uuid
           batch_item.repo_object_class_name ||= 'GenericWork'
         else
           batch_item.repo_object_id = nil

--- a/spec/features/batches/batch_summary_spec.rb
+++ b/spec/features/batches/batch_summary_spec.rb
@@ -8,7 +8,7 @@ describe 'Batch Summary', type: :feature do
 
     # calculate some totals expected for the summary
     let(:num_finished) do
-      batch_items.select { |batch_item| batch_item.status.in? ['completed', 'failed', 'expunged'] }.count
+      batch_items.select { |batch_item| batch_item.status.in? ['completed', 'failed'] }.count
     end
     let(:num_remaining) { batch_items.count - num_finished }
     let(:num_errors) { batch_items.select(&:error).count }

--- a/spec/features/batches/show_batch_details_spec.rb
+++ b/spec/features/batches/show_batch_details_spec.rb
@@ -10,12 +10,15 @@ describe 'Show Batches Data', type: :feature do
       # make a list of batch items, 1-3 for each different status.
       let(:batch_items) do
         Hyrax::BatchIngest::BatchItem::STATUSES.map do |status|
-          build_list(:batch_item, 2, status: status)
+          if status == 'completed'
+            # Create real repo object for 'completed' batch items.
+            build_list(:batch_item, rand(1..3), repo_object_id: ActiveFedora::Base.create.id, status: 'completed')
+          else
+            build_list(:batch_item, rand(1..3), status: status)
+          end
         end.flatten
       end
-
       let(:completed_batch_items) { batch_items.select { |batch_item| batch_item.status == 'completed' } }
-
       let(:batch) { create(:batch, batch_items: batch_items) }
       before do
         visit batch_path(id: batch.id)

--- a/spec/models/hyrax/batch_ingest/batch_item_spec.rb
+++ b/spec/models/hyrax/batch_ingest/batch_item_spec.rb
@@ -13,6 +13,24 @@ RSpec.describe Hyrax::BatchIngest::BatchItem do
     end
   end
 
+  describe 'repo_object_exists?' do
+    subject { build(:batch_item, status: 'completed', repo_object_id: repo_object_id).repo_object_exists? }
+    context 'repo_object_id is nil' do
+      let(:repo_object_id) { nil }
+      it { is_expected.to eq false }
+    end
+
+    context 'when repo_object_id is not in the repo' do
+      let(:repo_object_id) { 'does-not-exist' }
+      it { is_expected.to eq false }
+    end
+
+    context 'when repo_object_id does exsit in the repo' do
+      let(:repo_object_id) { ActiveFedora::Base.create.id }
+      it { is_expected.to eq true }
+    end
+  end
+
   describe 'methods delegated to Batch' do
     let(:batch) { build(:batch, submitter_email: "submitter@example.org") }
     let(:batch_item) { build(:batch_item, batch: batch) }


### PR DESCRIPTION
This reverts a previous commit where we added 'expunged' to the list of allowed
values for BatchItem#status. This was to accomodate apps who may need to remove
and object that had been ingested.

However, instead of switching status to 'expunged', this PR leaves the status
as it was, and looks for a missing repo_object_id. If the repo_object_id is
missing, this is indicated by a different icon (trashcan) and the word
'Gone' in the column for 'Repository ID' in the batches#show view.